### PR TITLE
Feat/refactoring code

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,12 +21,12 @@ KIS_VIRTUAL=true
 NEO4J_AUTH=neo4j/password
 
 # Local development
-NEO4J_URI=bolt://localhost:7687
+NEO4J_URI=bolt://localhost:21005
 NEO4J_USER=neo4j
 NEO4J_PASSWORD=password
 
 # Docker environment (use container name)
-# NEO4J_URI=bolt://stockelper-neo4j:7687
+# NEO4J_URI=bolt://stockelper-neo4j:21005
 
 # MongoDB (for competitor data)
 # Local development

--- a/.gitignore
+++ b/.gitignore
@@ -205,3 +205,5 @@ cython_debug/
 marimo/_static/
 marimo/_lsp/
 __marimo__/
+data/
+docs_cache/

--- a/README.md
+++ b/README.md
@@ -1,17 +1,17 @@
 # 📊 Stockelper-KG: 한국 주식 지식 그래프 생성기
 
 한국 주식 시장 데이터를 기반으로 **Neo4j 지식 그래프**를 구축하는 프로덕션급 Python 패키지입니다.
-한국투자증권 API, OpenDART, KRX API 등을 활용하여 기업 정보, 주가, 재무제표, 경쟁사 관계를 수집하고 Neo4j 그래프 데이터베이스로 구조화합니다.
+한국투자증권 API, OpenDART, KRX API, MongoDB를 활용해 기업·시세·재무·경쟁사 관계를 수집하고, 온톨로지 기반 뉴스/이벤트 그래프까지 통합합니다.
 
 ## ✨ 주요 기능
 
-- 🔄 **스트리밍 모드**: 메모리 효율적인 배치 처리 및 중단 시 자동 재시작
+- 🔄 **스트리밍 모드**: 메모리 효율적 수집, 중단 시 자동 재시작, 기존 데이터 자동 스킵
 - 📊 **다양한 데이터 소스**: KRX, 한국투자증권, OpenDART, MongoDB 통합
-- 🎯 **모듈화 설계**: 확장 가능하고 테스트 가능한 아키텍처
-- 🔍 **중복 체크**: Neo4j 기반 자동 중복 검사 및 증분 업데이트
-- ⚡ **성능 최적화**: 배치 쿼리 및 트랜잭션 관리
-- 🧪 **테스트 완비**: pytest 기반 단위 테스트 및 커버리지 리포팅
-- 🐳 **Docker 지원**: 완전한 컨테이너화 및 docker-compose 설정
+- 🎯 **모듈화 설계**: 수집기/그래프 빌더/온톨로지 분리로 확장성 확보
+- 🔍 **중복 체크**: Neo4j constraint를 활용한 안전한 MERGE 업서트
+- 🧠 **뉴스 이벤트 파이프라인**: GPT-4o + 이벤트 온톨로지 기반 분류·그래프 업서트
+- ⚡ **효율적 트랜잭션**: 배치 MERGE 쿼리 및 constraint 자동 생성
+- 🐳 **Docker 지원**: `docker-compose`로 Neo4j 포함 로컬 스택 기동
 
 ---
 
@@ -19,9 +19,9 @@
 
 ### 필수 요구사항
 
-- **Python 3.12** (3.13 미만)
-- **Docker + Docker Compose** (Neo4j 실행용)
-- **uv** (Python 패키지 관리자)
+- Python 3.12 (3.13 미만)
+- Docker + Docker Compose (Neo4j 실행)
+- uv (Python 패키지 관리자)
   ```bash
   # Linux/macOS
   curl -LsSf https://astral.sh/uv/install.sh | sh
@@ -38,10 +38,9 @@
 docker compose up -d
 ```
 
-**접속 정보:**
 - HTTP: `http://localhost:21004`
 - Bolt: `bolt://localhost:21005`
-- 기본 인증: `neo4j / password`
+- 기본 인증: `neo4j / password` (`NEO4J_AUTH`로 변경 가능)
 
 #### 2. 환경 변수 설정
 
@@ -49,26 +48,37 @@ docker compose up -d
 cp .env.example .env
 ```
 
-`.env` 파일에 필수 API 키 입력:
+`.env`에 필수 키 입력:
+
 ```bash
-# OpenDART API 키 (필수)
+# OpenDART
 OPEN_DART_API_KEY=your_dart_api_key
 
-# 한국투자증권 API (필수)
+# 한국투자증권
 KIS_APP_KEY=your_kis_app_key
 KIS_APP_SECRET=your_kis_app_secret
-KIS_ACCESS_TOKEN=  # 자동 갱신됨
+KIS_ACCESS_TOKEN=
+KIS_ACCESS_NUMBER=
+KIS_ACCOUNT_NUMBER=
+KIS_ACCOUNT_CODE=
+KIS_VIRTUAL=true
 
 # Neo4j (docker-compose 기본값)
 NEO4J_URI=bolt://localhost:21005
 NEO4J_USER=neo4j
 NEO4J_PASSWORD=password
+NEO4J_AUTH=neo4j/password
 
 # MongoDB (경쟁사 데이터)
 DB_URI=mongodb://localhost:27017
 DB_NAME=stockelper
 DB_COLLECTION_NAME=competitors
+
+# OpenAI (뉴스/이벤트 파이프라인)
+OPENAI_API_KEY=sk-your-openai-key
 ```
+
+> 뉴스/이벤트 파이프라인을 사용하려면 `OPENAI_API_KEY`가 반드시 필요합니다.
 
 #### 3. 의존성 설치
 
@@ -78,20 +88,43 @@ uv sync
 
 #### 4. 데이터 수집 및 그래프 구축
 
-**스트리밍 모드 (권장):**
 ```bash
-# 특정 날짜 데이터 수집 (중복 자동 스킵)
+# 권장: 스트리밍 모드 (처리된 종목 자동 스킵)
 uv run stockelper-kg --date_st 20250101 --date_fn 20250101 --streaming
 
-# 배치 크기 조정 (기본값: 100)
-uv run stockelper-kg --date_st 20250101 --date_fn 20250101 --streaming --batch-size 50
+# 병렬 수집 (API 레이트리밋 고려해 2~4 추천)
+uv run stockelper-kg --date_st 20250101 --date_fn 20250101 --streaming --max-workers 4
+
+# 기존 그래프 무시 후 전체 재처리
+uv run stockelper-kg --date_st 20250101 --date_fn 20250101 --streaming --no-skip-existing
+
+# 기존 그래프에 새 날짜만 추가
+uv run stockelper-kg --date_st 20250110 --date_fn 20250110 --streaming --update-only
 ```
 
-**레거시 모드:**
+레거시 배치 모드(전량 메모리 적재, 재시작 불가):
+
 ```bash
-# 전체 데이터를 메모리에 적재 (비권장)
 uv run stockelper-kg --date_st 20250101 --date_fn 20250101
 ```
+
+#### 5. 뉴스/이벤트 파이프라인 실행
+
+GPT-4o와 온톨로지를 사용해 뉴스를 이벤트 그래프로 분류·업서트합니다. `corp_name`/`date`가 해석되면 KRX/KIS/DART 데이터를 추가 수집해 회사 스냅샷도 최신화합니다.
+
+```bash
+# 단일 파일 처리
+uv run stockelper-kg-events --file data/news_articles/01_Samsung_P4_Expansion.txt
+
+# 폴더 내 모든 텍스트 처리
+uv run stockelper-kg-events --dir data/news_articles
+
+# JSONL 데이터셋 일괄 처리 (샘플 제공)
+uv run stockelper-kg-events --dataset data/news_test_cases.jsonl
+```
+
+- `--file` / `--dir` / `--dataset` 중 하나를 선택합니다.
+- JSONL 레코드는 `content`(또는 `text`) 필드에 기사 본문을 넣고, 선택적으로 `metadata`(dict)나 `content_file`(본문 파일 경로) 필드를 사용할 수 있습니다.
 
 ---
 
@@ -99,73 +132,68 @@ uv run stockelper-kg --date_st 20250101 --date_fn 20250101
 
 ### CLI 명령어
 
-#### 기본 사용
+**stockelper-kg** (데이터 수집/그래프 구축)
 
 ```bash
-# 스트리밍 모드로 특정 날짜 데이터 수집
 uv run stockelper-kg --date_st 20250101 --date_fn 20250101 --streaming
+uv run stockelper-kg --date_st 20250101 --date_fn 20250101 --streaming --max-workers 2
+uv run stockelper-kg --date_st 20250110 --date_fn 20250110 --streaming --update-only
+uv run stockelper-kg --date_st 20250101 --date_fn 20250101 --streaming --env /path/to/.env
 ```
 
-#### 고급 옵션
+**stockelper-kg-events** (뉴스/이벤트 업서트)
 
 ```bash
-# 배치 크기 조정 (메모리 사용량 제어)
-uv run stockelper-kg --date_st 20250101 --date_fn 20250101 --streaming --batch-size 50
-
-# 기존 데이터 재처리 (중복 스킵 비활성화)
-uv run stockelper-kg --date_st 20250101 --date_fn 20250101 --streaming --no-skip-existing
-
-# 증분 업데이트 (기존 종목에 새 날짜만 추가)
-uv run stockelper-kg --date_st 20250110 --date_fn 20250110 --streaming --update-only
-
-# 커스텀 .env 파일 사용
-uv run stockelper-kg --date_st 20250101 --date_fn 20250101 --env /path/to/.env --streaming
+uv run stockelper-kg-events --file path/to/article.txt --env .env
+uv run stockelper-kg-events --dataset data/news_test_cases.jsonl
 ```
 
 ### Python API 사용
 
 ```python
 from stockelper_kg.config import Config
+from stockelper_kg.collectors.streaming_orchestrator import StreamingOrchestrator
 from stockelper_kg.graph import Neo4jClient
-from stockelper_kg.collectors import StreamingOrchestrator
 from stockelper_kg.utils import get_date_list
 
-# 설정 로드
 config = Config.from_env(".env")
 
-# Neo4j 클라이언트 초기화
 client = Neo4jClient(config.neo4j)
 client.ensure_constraints()
 
-# 날짜 리스트 생성
 date_list = get_date_list("20250101", "20250101")
 
-# 스트리밍 오케스트레이터 생성
 orchestrator = StreamingOrchestrator(
     config=config,
     date_list=date_list,
     neo4j_client=client,
-    batch_size=100,
+    env_path=".env",
     skip_existing=True,
+    max_workers=2,
 )
-
-# 데이터 수집 및 그래프 구축
 stats = orchestrator.run_streaming()
 print(f"처리 완료: {stats}")
 
-# 연결 종료
 client.close()
+```
+
+이벤트 파이프라인도 코드에서 동일하게 호출할 수 있습니다.
+
+```python
+from stockelper_kg.pipeline import create_pipeline
+
+pipeline = create_pipeline(Config.from_env(".env"))
+pipeline.process("기사 전문을 여기에 입력", metadata={"source": "example"})
 ```
 
 ### 스트리밍 모드 상세 가이드
 
-스트리밍 모드의 자세한 사용법은 [STREAMING_MODE.md](STREAMING_MODE.md)를 참고하세요.
+스트리밍 모드 설명은 `docs/STREAMING_MODE.md`를 참고하세요.
 
 **주요 장점:**
-- ✅ 메모리 효율적 (배치 크기만큼만 적재)
-- ✅ 중단 시 자동 재시작 (처리된 종목 스킵)
-- ✅ 실시간 진행상황 확인
-- ✅ 개별 종목 실패 시에도 계속 진행
+- ✅ 이미 처리된 종목 자동 스킵 및 재시작 지원
+- ✅ 메모리 사용 최소화 (종목 단위 처리)
+- ✅ 개별 종목 실패에도 전체 파이프라인 지속
 
 ---
 
@@ -173,134 +201,126 @@ client.close()
 
 ```
 stockelper-kg/
+├── data/
+│   ├── news_articles/                # 샘플 기사 전문
+│   └── news_test_cases.jsonl         # JSONL 샘플
+├── docs/
+│   └── STREAMING_MODE.md             # 스트리밍 모드 가이드
 ├── src/
 │   └── stockelper_kg/
 │       ├── __init__.py
-│       ├── cli.py                    # CLI 진입점
-│       ├── config.py                 # 설정 관리 (dataclass)
-│       ├── collectors/               # 데이터 수집 모듈
-│       │   ├── __init__.py
-│       │   ├── base.py              # 추상 베이스 클래스
-│       │   ├── krx.py               # KRX 거래소 데이터
-│       │   ├── kis.py               # 한국투자증권 API
-│       │   ├── dart.py              # OpenDART 재무제표
-│       │   ├── mongodb.py           # MongoDB 경쟁사 데이터
-│       │   ├── orchestrator.py      # 레거시 오케스트레이터
-│       │   └── streaming_orchestrator.py  # 스트리밍 오케스트레이터
-│       ├── graph/                    # Neo4j 그래프 관리
-│       │   ├── __init__.py
-│       │   ├── client.py            # Neo4j 클라이언트
-│       │   ├── queries.py           # Cypher 쿼리 빌더
-│       │   └── builder.py           # 그래프 빌더
-│       └── utils/                    # 유틸리티
-│           ├── __init__.py
-│           ├── decorators.py        # 성능 측정 데코레이터
-│           └── dates.py             # 날짜 처리 유틸
-├── tests/                            # 단위 테스트
+│       ├── cli.py                    # 메인 CLI
+│       ├── event_cli.py              # 뉴스/이벤트 CLI
+│       ├── config.py                 # 설정 관리
+│       ├── pipeline.py               # 이벤트 파이프라인
+│       ├── collectors/
+│       │   ├── base.py
+│       │   ├── dart.py
+│       │   ├── event.py
+│       │   ├── kis.py
+│       │   ├── krx.py
+│       │   ├── mongodb.py
+│       │   ├── orchestrator.py       # 레거시 배치 모드
+│       │   └── streaming_orchestrator.py
+│       ├── graph/
+│       │   ├── builder.py
+│       │   ├── client.py
+│       │   ├── cypher.py
+│       │   ├── event.py
+│       │   ├── ontology.py
+│       │   ├── payload.py
+│       │   ├── queries.py            # 레거시 Cypher 빌더
+│       │   └── schema.py
+│       └── utils/
+│           ├── dates.py
+│           └── decorators.py
+├── tests/
 │   ├── test_config.py
-│   ├── test_utils.py
-│   └── test_graph_queries.py
-├── scripts/                          # 실행 스크립트
-│   ├── run_with_uv.sh
-│   └── entrypoint.sh
-├── docker-compose.yml                # Neo4j 컨테이너 설정
-├── Dockerfile                        # 애플리케이션 컨테이너
-├── pyproject.toml                    # 프로젝트 메타데이터
-├── .env.example                      # 환경 변수 템플릿
-├── README.md                         # 이 파일
-└── STREAMING_MODE.md                 # 스트리밍 모드 가이드
+│   ├── test_graph_queries.py
+│   └── test_utils.py
+├── docker-compose.yml
+├── Dockerfile
+├── pyproject.toml
+└── README.md
 ```
 
 ### 모듈 설명
 
-#### Collectors (데이터 수집)
-- **BaseCollector**: 모든 수집기의 추상 베이스 클래스
-- **KRXCollector**: 한국거래소 상장 종목 정보
-- **KISCollector**: 한국투자증권 API (주가, 회사 정보)
-- **DartCollector**: OpenDART API (재무제표)
-- **MongoDBCollector**: MongoDB에서 경쟁사 관계 조회
-- **StreamingOrchestrator**: 배치 스트리밍 및 재시작 지원
+**Collectors**
+- `BaseCollector`: 공통 대기/로깅 유틸
+- `KRXCollector`: 상장 종목 정보
+- `KISCollector`: 한국투자증권 API (주가/기업 정보)
+- `DartCollector`: OpenDART 재무제표
+- `MongoDBCollector`: 경쟁사 데이터
+- `DataOrchestrator`: 레거시 일괄 수집
+- `StreamingOrchestrator`: 스트리밍 수집 및 재시작 지원
+- `EventCollector`: 이벤트 파이프라인용 단일 종목 스냅샷 수집기
 
-#### Graph (그래프 데이터베이스)
-- **Neo4jClient**: Neo4j 연결 및 트랜잭션 관리
-- **GraphBuilder**: 노드 및 관계 생성 로직
-- **queries.py**: Cypher 쿼리 생성 함수
+**Graph**
+- `Neo4jClient`: 연결 관리, constraint 생성, 기본 쿼리 헬퍼
+- `GraphBuilder`: 수집된 DataFrame → 그래프 페이로드 생성 후 MERGE
+- `cypher.py`: `GraphPayload` → Cypher MERGE 문 변환 및 constraint 생성
+- `ontology.py`: 노드/엣지/이벤트 온톨로지 정의 (LLM 프롬프트 & PK 매핑)
+- `payload.py`: 이벤트/주가 스냅샷/경쟁사 GraphPayload 빌더
+- `schema.py`: GraphPayload/노드/엣지 데이터 구조
+- `event.py`: GPT-4o 기반 이벤트 분류
+- `queries.py`: 레거시 Cypher 생성기
 
-#### Utils (유틸리티)
-- **measure_time**: 함수 실행 시간 측정 데코레이터
-- **get_date_list**: 날짜 범위 생성
+**News / Event Pipeline**
+- `event_cli.py`: 파일/디렉터리/JSONL 입력을 받아 이벤트 업서트
+- `pipeline.EventPipeline`: LLM 분류 → 그래프 업서트 → 필요 시 KRX/KIS/DART 재수집
+- `collectors.event.EventCollector`: 단일 종목의 가격/재무/경쟁사 데이터를 병합 수집
+- 샘플 데이터: `data/news_articles`, `data/news_test_cases.jsonl`
+
+**Utils**
+- `measure_time` (`decorators.py`): 실행 시간 측정
+- `get_date_list`, `normalize_date`, `build_date_properties` (`dates.py`)
 
 ---
 
 ## 🧪 개발 및 테스트
 
-### 테스트 실행
-
 ```bash
-# 모든 테스트 실행
+# 모든 테스트 실행 (pyproject의 기본 addopts 포함)
 uv run pytest
 
-# 커버리지 리포트 포함
+# 커버리지 HTML 리포트 추가
 uv run pytest --cov=src/stockelper_kg --cov-report=html
 
-# 특정 테스트 파일만 실행
+# 특정 테스트만 실행
 uv run pytest tests/test_config.py -v
 ```
 
 ### 코드 품질 도구
 
 ```bash
-# 코드 포맷팅 (Black)
 uv run black src/ tests/
-
-# Import 정렬 (isort)
 uv run isort src/ tests/
-
-# 린팅 (flake8)
 uv run flake8 src/ tests/
-
-# 타입 체크 (mypy)
 uv run mypy src/
-
-# 모든 품질 검사 한번에
-uv run black src/ tests/ && uv run isort src/ tests/ && uv run flake8 src/ tests/
 ```
 
 ### 개발 환경 설정
 
 ```bash
-# 개발 의존성 포함 설치
 uv sync
-
-# 패키지를 editable 모드로 설치
 uv pip install -e .
 ```
 
 ## 🐳 Docker 배포
 
-### Docker Compose로 전체 스택 실행
-
 ```bash
-# Neo4j 시작
-docker compose up -d
-
-# 로그 확인
-docker compose logs -f neo4j
-
-# 중지
-docker compose down
-
-# 데이터 포함 완전 삭제
-docker compose down -v
+docker network create stockelper   # 최초 1회: compose에서 사용하는 네트워크
+docker compose up -d           # Neo4j 시작
+docker compose logs -f neo4j   # 로그 확인
+docker compose down            # 중지
+docker compose down -v         # 데이터까지 삭제
 ```
 
-### 애플리케이션 컨테이너 빌드
+애플리케이션 이미지는 다음과 같이 실행합니다.
 
 ```bash
-# 이미지 빌드
 docker build -t stockelper-kg:latest .
-
-# 컨테이너 실행
 docker run --rm \
   --env-file .env \
   --network stockelper \
@@ -318,13 +338,20 @@ docker run --rm \
 | `KIS_APP_KEY` | 한국투자증권 앱 키 | ✅ | - |
 | `KIS_APP_SECRET` | 한국투자증권 시크릿 | ✅ | - |
 | `KIS_ACCESS_TOKEN` | 액세스 토큰 (자동 갱신) | ❌ | - |
+| `KIS_ACCESS_NUMBER` | 사용자 식별 번호 | ❌ | - |
+| `KIS_ACCOUNT_NUMBER` | 계좌번호 | ❌ | - |
+| `KIS_ACCOUNT_CODE` | 계좌 구분 코드 | ❌ | - |
 | `KIS_VIRTUAL` | 모의투자 모드 | ❌ | `true` |
 | `NEO4J_URI` | Neo4j Bolt URI | ✅ | `bolt://localhost:21005` |
 | `NEO4J_USER` | Neo4j 사용자명 | ✅ | `neo4j` |
 | `NEO4J_PASSWORD` | Neo4j 비밀번호 | ✅ | `password` |
+| `NEO4J_AUTH` | Docker용 Neo4j 인증 | ❌ | `neo4j/password` |
 | `DB_URI` | MongoDB URI | ✅ | `mongodb://localhost:27017` |
 | `DB_NAME` | MongoDB 데이터베이스명 | ✅ | `stockelper` |
 | `DB_COLLECTION_NAME` | MongoDB 컬렉션명 | ✅ | `competitors` |
+| `OPENAI_API_KEY` | 뉴스/이벤트 파이프라인용 GPT-4o 키 | ❌* | - |
+
+\* `stockelper-kg-events` 실행 시 필수
 
 ### CLI 옵션
 
@@ -333,97 +360,57 @@ docker run --rm \
 | `--date_st` | 시작 날짜 (YYYYMMDD) | 필수 |
 | `--date_fn` | 종료 날짜 (YYYYMMDD) | 필수 |
 | `--streaming` | 스트리밍 모드 활성화 | `False` |
-| `--batch-size` | 배치 크기 (종목 수) | `100` |
-| `--no-skip-existing` | 기존 종목 재처리 | `False` |
-| `--update-only` | 증분 업데이트만 수행 | `False` |
+| `--max-workers` | 병렬 워커 수 (None이면 순차 처리) | `None` |
+| `--no-skip-existing` | 이미 처리된 종목도 재처리 | `False` |
+| `--update-only` | 기존 그래프에 새 날짜만 추가 (스트리밍 전용) | `False` |
 | `--env` | .env 파일 경로 | `.env` |
 
-## 📊 성능 최적화
+## 📊 운영 팁
 
-### 메모리 사용량
-
-| 모드 | 메모리 사용량 | 2,879개 종목 기준 |
-|------|--------------|------------------|
-| 레거시 (일괄) | ~8GB | 전체 DataFrame 적재 |
-| 스트리밍 (배치 100) | ~300MB | 100개씩 처리 |
-| 스트리밍 (배치 50) | ~150MB | 50개씩 처리 |
-
-### 권장 설정
-
-**초기 로드 (안정성 우선):**
-```bash
-uv run stockelper-kg --date_st 20250101 --date_fn 20250101 --streaming --batch-size 50
-```
-
-**일일 업데이트 (속도 우선):**
-```bash
-uv run stockelper-kg --date_st 20250110 --date_fn 20250110 --streaming --update-only
-```
-
-**대량 재처리:**
-```bash
-uv run stockelper-kg --date_st 20250101 --date_fn 20250101 --streaming --batch-size 200 --no-skip-existing
-```
-
----
+- 스트리밍 모드가 기본이며, Neo4j에 존재하는 종목은 자동 스킵됩니다. 전체 재처리가 필요하면 `--no-skip-existing`을 사용하세요.
+- 레이트리밋을 피하려면 `--max-workers`를 2~4 사이로 설정하고 필요 시 순차 처리로 전환하세요.
+- 일일 업데이트에는 `--update-only`가 가장 빠릅니다.
+- 레거시 모드는 모든 데이터를 메모리에 적재하므로 대규모 데이터에는 비권장입니다.
 
 ## 🔄 마이그레이션 가이드
 
-### 기존 코드에서 마이그레이션
+**기존 방식:**
 
-**이전 방식:**
 ```python
 from stock_graph import StockGraph
 from stock_knowledge_graph import StockKnowledgeGraph
-
-# 실행
 python run_graphdb.py --date_st 20250101 --date_fn 20250101
 ```
 
-**새로운 방식:**
+**현재 방식:**
+
 ```python
 from stockelper_kg.collectors import StreamingOrchestrator
 from stockelper_kg.graph import Neo4jClient
 from stockelper_kg.config import Config
 
-# 실행
 uv run stockelper-kg --date_st 20250101 --date_fn 20250101 --streaming
 ```
 
 ### 주요 변경사항
 
-1. **모듈 구조**: 단일 파일 → 패키지 구조
-2. **설정 관리**: 하드코딩 → dataclass 기반 설정
-3. **데이터 처리**: 일괄 처리 → 스트리밍 처리
-4. **에러 처리**: 전체 실패 → 개별 종목 격리
-5. **재시작**: 처음부터 → 중단 지점부터
-
-자세한 내용은 [REFACTORING_SUMMARY.md](REFACTORING_SUMMARY.md)를 참고하세요.
+1. 단일 파일 스크립트 → 패키지 구조
+2. 설정 하드코딩 → dataclass 기반 `Config.from_env`
+3. 일괄 처리 → 스트리밍 + 자동 재시작
+4. LLM 이벤트 온톨로지 추가 (`stockelper-kg-events`)
 
 ## 🐛 문제 해결
 
-### 자주 묻는 질문
-
-**Q: 중복 데이터가 생성됩니다**
-- A: Neo4j의 UNIQUE constraint가 설정되어 있는지 확인하세요. 첫 실행 시 자동으로 생성됩니다.
-
-**Q: 메모리 부족 오류가 발생합니다**
-- A: `--batch-size`를 더 작게 설정하세요 (예: 25 또는 50).
-
-**Q: API 토큰이 만료되었습니다**
-- A: 500 에러 발생 시 자동으로 재발급되며 `.env` 파일에 저장됩니다.
-
-**Q: 특정 종목만 재처리하고 싶습니다**
-- A: 현재는 전체 재처리만 지원합니다. 향후 업데이트 예정입니다.
-
-**Q: Neo4j 연결이 안됩니다**
-- A: `docker compose ps`로 Neo4j가 실행 중인지 확인하고, `.env` 파일의 포트 번호를 확인하세요 (기본: 21005).
+- **중복 데이터 생성**: 첫 실행 시 `Neo4jClient.ensure_constraints()`가 constraint를 생성합니다. 스키마 권한을 확인하세요.
+- **메모리 부족**: 스트리밍 모드에서 실행하거나 병렬 워커 수를 줄이세요.
+- **API 토큰 만료**: KIS 토큰은 자동 재발급되어 `.env`에 저장됩니다. 실패 시 재시도하세요.
+- **Neo4j 연결 실패**: `docker compose ps`로 컨테이너 상태를 확인하고 포트(`21005`)와 비밀번호를 점검하세요.
 
 ## 📚 추가 문서
 
-- [스트리밍 모드 가이드](STREAMING_MODE.md) - 스트리밍 모드 상세 사용법
-- [리팩토링 요약](REFACTORING_SUMMARY.md) - 프로젝트 구조 변경 내역
-- [.env.example](.env.example) - 환경 변수 템플릿
+- `docs/STREAMING_MODE.md` - 스트리밍 모드 가이드
+- `.env.example` - 환경 변수 템플릿
+- `data/news_test_cases.jsonl` - 이벤트 파이프라인 입력 예시
 
 ## 🤝 기여하기
 
@@ -433,15 +420,15 @@ uv run stockelper-kg --date_st 20250101 --date_fn 20250101 --streaming
 4. Push to the branch (`git push origin feature/amazing-feature`)
 5. Open a Pull Request
 
-**코드 스타일:**
+**코드 스타일**
 - Black (line length 88)
 - isort (black profile)
-- Type hints 사용
-- Docstring 작성 (Google style)
+- Type hints 권장
+- Google 스타일 Docstring
 
 ## 📜 라이선스
 
-MIT License - 자세한 내용은 [LICENSE](LICENSE) 파일을 참고하세요.
+MIT License - [LICENSE](LICENSE) 참고
 
 ## 👨‍💻 개발자
 
@@ -450,7 +437,7 @@ MIT License - 자세한 내용은 [LICENSE](LICENSE) 파일을 참고하세요.
 
 ## 📞 문의
 
-문제가 발생하거나 제안사항이 있으시면 GitHub Issues를 통해 알려주세요.
+문제가 발생하거나 제안사항이 있으시면 GitHub Issues로 알려주세요.
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,10 +20,13 @@ dependencies = [
   "tqdm>=4.65,<5",
   "pymongo>=4.3,<5",
   "finance-datareader>=0.9.90,<1.0",
+  "openai>=1.0.0",
+  "beautifulsoup4>=4.9.0",
 ]
 
 [project.scripts]
 stockelper-kg = "stockelper_kg.cli:cli"
+stockelper-kg-events = "stockelper_kg.event_cli:cli"
 
 [build-system]
 requires = ["hatchling"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -62,3 +62,4 @@ tzdata==2025.2
 ujson==5.11.0
 urllib3==2.5.0
 wheel==0.45.1
+openai>=1.0.0

--- a/src/stockelper_kg/cli.py
+++ b/src/stockelper_kg/cli.py
@@ -3,6 +3,7 @@
 import argparse
 import logging
 from datetime import datetime
+from typing import Optional
 
 from tqdm import tqdm
 
@@ -50,10 +51,12 @@ def parse_args():
         help="Use streaming mode with resume capability (recommended)",
     )
     parser.add_argument(
-        "--batch-size",
+        "--max-workers",
         type=int,
-        default=100,
-        help="Batch size for streaming mode (default: 100)",
+        default=None,
+        help="Maximum number of parallel workers. "
+        "If not set, processes sequentially. Recommended: 2-4 to avoid API rate limits. "
+        "(default: None = sequential)",
     )
     parser.add_argument(
         "--no-skip-existing",
@@ -83,7 +86,7 @@ def main(
     date_fn: str,
     env_path: str = ".env",
     streaming: bool = False,
-    batch_size: int = 100,
+    max_workers: Optional[int] = None,
     skip_existing: bool = True,
     update_only: bool = False,
 ):
@@ -94,7 +97,7 @@ def main(
         date_fn: End date in YYYYMMDD format
         env_path: Path to .env file
         streaming: Use streaming mode with resume capability
-        batch_size: Batch size for streaming mode
+        max_workers: Maximum number of parallel workers. If None, processes sequentially
         skip_existing: Skip stocks that already exist in database
         update_only: Only update existing stocks with new dates
     """
@@ -117,8 +120,8 @@ def main(
             date_list=date_list,
             neo4j_client=client,
             env_path=env_path,
-            batch_size=batch_size,
             skip_existing=skip_existing,
+            max_workers=max_workers,
         )
 
         if update_only:
@@ -158,7 +161,7 @@ def cli():
         date_fn=args.date_fn,
         env_path=args.env,
         streaming=args.streaming,
-        batch_size=args.batch_size,
+        max_workers=args.max_workers,
         skip_existing=not args.no_skip_existing,
         update_only=args.update_only,
     )

--- a/src/stockelper_kg/collectors/__init__.py
+++ b/src/stockelper_kg/collectors/__init__.py
@@ -5,12 +5,15 @@ from .kis import KISCollector
 from .krx import KRXCollector
 from .mongodb import MongoDBCollector
 from .orchestrator import DataOrchestrator
+from .event import EventCollector
 from .streaming_orchestrator import StreamingOrchestrator
 
 __all__ = [
     "DataOrchestrator",
-    "StreamingOrchestrator",
-    "KISCollector",
     "DartCollector",
+    "KISCollector",
+    "KRXCollector",
     "MongoDBCollector",
+    "EventCollector",
+    "StreamingOrchestrator",
 ]

--- a/src/stockelper_kg/collectors/dart.py
+++ b/src/stockelper_kg/collectors/dart.py
@@ -1,27 +1,19 @@
 """OpenDart API collector for financial statements."""
 
 import time
-from typing import List
 
 import pandas as pd
 import OpenDartReader
 
 from .base import BaseCollector
+from ..utils.dates import normalize_date
 
 
 class DartCollector(BaseCollector):
-    """Collector for OpenDart financial statement data."""
-
     def __init__(self, api_key: str, sleep_seconds: float = 0.1):
-        """Initialize DART collector.
-
-        Args:
-            api_key: OpenDart API key
-            sleep_seconds: Seconds to sleep between API calls
-        """
         super().__init__(sleep_seconds)
         self.dart = OpenDartReader(api_key)
-        self.column_names = [
+        self.columns_kr = [
             "매출액",
             "영업이익",
             "당기순이익",
@@ -30,7 +22,7 @@ class DartCollector(BaseCollector):
             "자본총계",
             "자본금",
         ]
-        self.column_names_eng = [
+        self.columns_en = [
             "revenue",
             "operating_income",
             "net_income",
@@ -40,18 +32,9 @@ class DartCollector(BaseCollector):
             "capital_stock",
         ]
 
-    def _get_quarter_list(self, date: str) -> List[tuple]:
-        """Get quarter list based on date.
-
-        Args:
-            date: Date in YYYYMMDD format
-
-        Returns:
-            List of (year, report_code, quarter_name) tuples
-        """
+    def collect_financial_statement(self, stock_code: str, date: str) -> pd.DataFrame:
         year = int(date[:4])
         month = int(date[4:6])
-
         if month in [1, 2, 3]:
             quarters = [(year - 1, "11011", "4")]
         elif month in [4, 5, 6]:
@@ -69,88 +52,69 @@ class DartCollector(BaseCollector):
                 (year, "11013", "1"),
                 (year - 1, "11011", "4"),
             ]
-        return quarters
 
-    def collect_financial_statement(
-        self, stock_code: str, date: str
-    ) -> pd.DataFrame:
-        """Collect financial statement for a stock.
-
-        Args:
-            stock_code: 6-digit stock code
-            date: Date in YYYYMMDD format
-
-        Returns:
-            DataFrame with financial statement data
-        """
-        for bsns_year, reprt_code, quarter_nm in self._get_quarter_list(date):
+        for bsns_year, reprt_code, quarter_nm in quarters:
             try:
-                self.logger.debug(
-                    f"Financial Statements: (stock_code: {stock_code}, year: {bsns_year}, quarter: {quarter_nm})"
-                )
                 dart_df = self.dart.finstate(
                     corp=stock_code, bsns_year=str(bsns_year), reprt_code=reprt_code
                 )
-
                 if dart_df is None or len(dart_df) == 0:
                     continue
 
                 fs_info = []
-                for col_nm in self.column_names:
+                for col_nm in self.columns_kr:
                     try:
-                        value = dart_df[
-                            (dart_df["account_nm"] == col_nm)
-                            & (dart_df["fs_nm"] == "연결재무제표")
-                        ]["thstrm_amount"].values
+                        mask = (dart_df["account_nm"] == col_nm) & (
+                            dart_df["fs_nm"] == "연결재무제표"
+                        )
+                        value = dart_df.loc[mask, "thstrm_amount"].values
                         if len(value) == 0:
-                            value = dart_df[
-                                (dart_df["account_nm"] == col_nm)
-                                & (dart_df["fs_nm"] == "재무제표")
-                            ]["thstrm_amount"].values
+                            mask = (dart_df["account_nm"] == col_nm) & (
+                                dart_df["fs_nm"] == "재무제표"
+                            )
+                            value = dart_df.loc[mask, "thstrm_amount"].values
                         fs_info.append(
                             int(value[0].replace(",", "")) if len(value) > 0 else 0
                         )
                     except Exception:
                         fs_info.append(0)
 
-                fs_df = pd.DataFrame([fs_info], columns=self.column_names_eng)
+                reported_date = None
+                if "thstrm_dt" in dart_df.columns:
+                    value = dart_df["thstrm_dt"].dropna().astype(str).head(1)
+                    if not value.empty:
+                        reported_date = normalize_date(value.iloc[0])
+
+                fs_df = pd.DataFrame([fs_info], columns=self.columns_en)
                 fs_df["year"] = bsns_year
                 fs_df["quarter"] = quarter_nm
                 fs_df["stock_code"] = stock_code
-                fs_df = fs_df[["stock_code", "year", "quarter"] + self.column_names_eng]
-                return fs_df
+                fs_df["reported_date"] = reported_date
+                return fs_df[
+                    ["stock_code", "year", "quarter", "reported_date", *self.columns_en]
+                ]
 
             except Exception as e:
                 self.logger.debug(f"Error fetching data for {stock_code}: {e}")
                 continue
 
-        # Return zeros if all quarters fail
         self.logger.warning(f"No available financial data for {stock_code}")
-        fs_df = pd.DataFrame([[0] * len(self.column_names_eng)], columns=self.column_names_eng)
+        fs_df = pd.DataFrame([[0] * len(self.columns_en)], columns=self.columns_en)
         fs_df["year"] = bsns_year
         fs_df["quarter"] = quarter_nm
         fs_df["stock_code"] = stock_code
-        fs_df = fs_df[["stock_code", "year", "quarter"] + self.column_names_eng]
-        return fs_df
+        fs_df["reported_date"] = None
+        return fs_df[
+            ["stock_code", "year", "quarter", "reported_date", *self.columns_en]
+        ]
 
     def collect(self, stock_codes: list, date: str) -> pd.DataFrame:
-        """Collect financial statements for all stocks.
-
-        Args:
-            stock_codes: List of stock codes
-            date: Date in YYYYMMDD format
-
-        Returns:
-            DataFrame with all financial statements
-        """
         from tqdm import tqdm
 
         fs_list = []
         for stock_code in tqdm(
             stock_codes, desc=f"Collecting financial statements (date: {date})"
         ):
-            fs = self.collect_financial_statement(stock_code, date)
-            fs_list.append(fs)
+            fs_list.append(self.collect_financial_statement(stock_code, date))
             time.sleep(self.sleep_seconds)
-
         return pd.concat(fs_list, ignore_index=True)

--- a/src/stockelper_kg/collectors/event.py
+++ b/src/stockelper_kg/collectors/event.py
@@ -1,0 +1,123 @@
+"""Event-driven data collector for knowledge graph construction."""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+
+import pandas as pd
+
+from .dart import DartCollector
+from .kis import KISCollector
+from .krx import KRXCollector
+from .mongodb import MongoDBCollector
+
+logger = logging.getLogger(__name__)
+
+_PRICE_COLUMNS = (
+    "stck_hgpr",
+    "stck_lwpr",
+    "stck_oprc",
+    "stck_clpr",
+    "stck_prpr",
+    "eps",
+    "pbr",
+    "per",
+)
+
+
+@dataclass
+class EventCollector:
+    """Collects and merges stock data for event-driven processing."""
+
+    dart: DartCollector
+    kis: KISCollector
+    krx: KRXCollector
+    competitors: MongoDBCollector | None = None
+
+    _stock_map: dict[str, str] = field(default_factory=dict, init=False)
+    _competitor_map: dict[str, list[str]] = field(default_factory=dict, init=False)
+    _krx_df: pd.DataFrame | None = field(default=None, init=False)
+
+    def resolve(self, corp_name: str) -> str | None:
+        """Resolve corp_name to stock code."""
+        self._ensure_stock_map()
+        return self._stock_map.get(corp_name)
+
+    def collect(self, stock_code: str, date: str) -> pd.DataFrame:
+        """Collect and merge all stock data for given code and date."""
+        date_clean = date.replace("-", "")
+
+        codes = [stock_code, *self._get_competitors(stock_code)]
+        krx_df = self._filter_krx(codes)
+        if krx_df.empty:
+            return pd.DataFrame()
+
+        krx_df = krx_df.copy()
+        krx_df["compete_code_li"] = [
+            self._get_competitors(c) for c in krx_df["stock_code"]
+        ]
+
+        company_df = self.kis.collect_company_info(stock_code)
+        if company_df is None:
+            logger.warning("[%s] No company info", stock_code)
+            company_df = pd.DataFrame([{"stock_code": stock_code}])
+
+        price_df = self.kis.collect_price_info(stock_code, date_clean, date_clean)
+        if price_df is None:
+            price_df = self._fill_price_info(stock_code, date_clean)
+
+        fs_df = self.dart.collect_financial_statement(stock_code, date_clean)
+
+        return (
+            krx_df.merge(company_df, on="stock_code", how="left")
+            .merge(price_df, on="stock_code", how="left")
+            .merge(fs_df, on="stock_code", how="left")
+        )
+
+    def _ensure_stock_map(self) -> None:
+        if self._stock_map:
+            return
+        logger.info("Building stock code map from KRX...")
+        df = self._get_krx()
+        self._stock_map = {
+            **dict(zip(df["stock_nm"], df["stock_code"])),
+            **dict(zip(df["stock_abbrv"], df["stock_code"])),
+        }
+
+    def _ensure_competitor_map(self) -> None:
+        if self._competitor_map:
+            return
+
+        if not self.competitors:
+            return
+
+        df = self.competitors.collect()
+        if df.empty:
+            return
+
+        for row in df.to_dict("records"):
+            code = str(row.get("stock_code", "")).strip()
+            if code:
+                rivals = row.get("compete_code_li") or []
+                self._competitor_map[code] = [
+                    str(v).strip() for v in rivals if str(v).strip()
+                ]
+
+    def _get_krx(self) -> pd.DataFrame:
+        if self._krx_df is None:
+            self._krx_df = self.krx.collect()
+        return self._krx_df
+
+    def _filter_krx(self, codes: list[str]) -> pd.DataFrame:
+        df = self._get_krx()
+        return df[df["stock_code"].isin(codes)]
+
+    def _get_competitors(self, stock_code: str) -> list[str]:
+        self._ensure_competitor_map()
+        return self._competitor_map.get(stock_code, [])
+
+    def _fill_price_info(self, stock_code: str, date: str) -> pd.DataFrame:
+        return pd.DataFrame(
+            [{"stock_code": stock_code, "date": date, **{c: 0 for c in _PRICE_COLUMNS}}]
+        )

--- a/src/stockelper_kg/collectors/kis.py
+++ b/src/stockelper_kg/collectors/kis.py
@@ -20,7 +20,9 @@ from .base import BaseCollector
 class KISCollector(BaseCollector):
     """Collector for Korea Investment & Securities API."""
 
-    def __init__(self, config: KISConfig, sleep_seconds: float = 0.1, env_path: str = ".env"):
+    def __init__(
+        self, config: KISConfig, sleep_seconds: float = 0.1, env_path: str = ".env"
+    ):
         """Initialize KIS collector.
 
         Args:
@@ -64,24 +66,28 @@ class KISCollector(BaseCollector):
             "appkey": self.config.app_key,
             "appsecret": self.config.app_secret,
         }
-        
+
         self.logger.info("Requesting new access token...")
         res = requests.post(url, headers=headers, data=json.dumps(data))
         response_data = res.json()
-        
+
         if res.status_code != 200:
-            self.logger.error(f"Token request failed: {res.status_code} - {response_data}")
-            raise requests.RequestException(f"Failed to get access token: {response_data}")
-        
+            self.logger.error(
+                f"Token request failed: {res.status_code} - {response_data}"
+            )
+            raise requests.RequestException(
+                f"Failed to get access token: {response_data}"
+            )
+
         new_token = response_data["access_token"]
         self.access_token = new_token
-        
+
         # Update .env file with new token
         self._update_env_file(new_token)
-        
+
         self.logger.info("Access token refreshed successfully")
         return new_token
-    
+
     def _update_env_file(self, new_token: str) -> None:
         """Update .env file with new access token.
 
@@ -93,27 +99,27 @@ class KISCollector(BaseCollector):
             if not env_file.exists():
                 self.logger.warning(f".env file not found at {self.env_path}")
                 return
-            
+
             # Read current .env content
-            content = env_file.read_text(encoding='utf-8')
-            
+            content = env_file.read_text(encoding="utf-8")
+
             # Update KIS_ACCESS_TOKEN value
             # Match pattern: KIS_ACCESS_TOKEN=<value> or KIS_ACCESS_TOKEN=
-            pattern = r'^(KIS_ACCESS_TOKEN=).*$'
-            replacement = f'KIS_ACCESS_TOKEN={new_token}'
-            
+            pattern = r"^(KIS_ACCESS_TOKEN=).*$"
+            replacement = f"KIS_ACCESS_TOKEN={new_token}"
+
             if re.search(pattern, content, re.MULTILINE):
                 # Replace existing token
                 new_content = re.sub(pattern, replacement, content, flags=re.MULTILINE)
             else:
                 # Add token if not exists
                 self.logger.warning("KIS_ACCESS_TOKEN not found in .env, appending...")
-                new_content = content.rstrip() + f'\n{replacement}\n'
-            
+                new_content = content.rstrip() + f"\n{replacement}\n"
+
             # Write back to file
-            env_file.write_text(new_content, encoding='utf-8')
+            env_file.write_text(new_content, encoding="utf-8")
             self.logger.info(f"Updated KIS_ACCESS_TOKEN in {self.env_path}")
-            
+
         except Exception as e:
             self.logger.error(f"Failed to update .env file: {e}")
 
@@ -160,30 +166,34 @@ class KISCollector(BaseCollector):
         for attempt in range(3):
             try:
                 res = self.session.get(url, headers=headers, params=params, timeout=30)
-                
+
                 # HTTP 상태 코드 체크 (500 에러 감지 - 토큰 만료 가능성)
                 if res.status_code >= 500:
                     self.logger.warning(
                         f"[{stock_code}] Server error {res.status_code} (attempt {attempt + 1}/3)"
                     )
-                    
+
                     # 첫 번째 시도에서 500 에러 시 토큰 재발급 시도
                     if attempt == 0:
-                        self.logger.info(f"[{stock_code}] Attempting to refresh access token...")
+                        self.logger.info(
+                            f"[{stock_code}] Attempting to refresh access token..."
+                        )
                         try:
                             self.access_token = self._refresh_access_token()
                             headers["authorization"] = f"Bearer {self.access_token}"
                             time.sleep(1)
                             continue
                         except Exception as e:
-                            self.logger.error(f"[{stock_code}] Token refresh failed: {e}")
-                    
+                            self.logger.error(
+                                f"[{stock_code}] Token refresh failed: {e}"
+                            )
+
                     if attempt < 2:
-                        time.sleep(3 ** attempt)  # 1초, 3초, 9초
+                        time.sleep(3**attempt)  # 1초, 3초, 9초
                         continue
                     else:
                         return None
-                
+
                 data = res.json()
 
                 if data.get("rt_cd") != "0":
@@ -251,30 +261,34 @@ class KISCollector(BaseCollector):
         for attempt in range(3):
             try:
                 res = self.session.get(url, headers=headers, params=params, timeout=30)
-                
+
                 # HTTP 상태 코드 체크 (500 에러 감지 - 토큰 만료 가능성)
                 if res.status_code >= 500:
                     self.logger.warning(
                         f"[{stock_code}] Server error {res.status_code} (attempt {attempt + 1}/3)"
                     )
-                    
+
                     # 첫 번째 시도에서 500 에러 시 토큰 재발급 시도
                     if attempt == 0:
-                        self.logger.info(f"[{stock_code}] Attempting to refresh access token...")
+                        self.logger.info(
+                            f"[{stock_code}] Attempting to refresh access token..."
+                        )
                         try:
                             self.access_token = self._refresh_access_token()
                             headers["authorization"] = f"Bearer {self.access_token}"
                             time.sleep(1)
                             continue
                         except Exception as e:
-                            self.logger.error(f"[{stock_code}] Token refresh failed: {e}")
-                    
+                            self.logger.error(
+                                f"[{stock_code}] Token refresh failed: {e}"
+                            )
+
                     if attempt < 2:
-                        time.sleep(3 ** attempt)  # 1초, 3초, 9초
+                        time.sleep(3**attempt)  # 1초, 3초, 9초
                         continue
                     else:
                         return None
-                
+
                 data = res.json()
 
                 if data.get("rt_cd") != "0":
@@ -292,13 +306,19 @@ class KISCollector(BaseCollector):
                     self.logger.warning(f"[{stock_code}] No price data")
                     return None
 
+                close_price = data["output2"][0].get("stck_clpr", 0)
+                present_price = data["output2"][0].get("stck_prpr")
+                if present_price in (None, ""):
+                    present_price = close_price
+
                 price_dict = {
                     "stock_code": stock_code,
                     "date": date_st,
                     "stck_hgpr": data["output2"][0].get("stck_hgpr", 0),
                     "stck_lwpr": data["output2"][0].get("stck_lwpr", 0),
                     "stck_oprc": data["output2"][0].get("stck_oprc", 0),
-                    "stck_clpr": data["output2"][0].get("stck_clpr", 0),
+                    "stck_clpr": close_price,
+                    "stck_prpr": present_price,
                     "eps": data["output1"].get("eps", 0),
                     "pbr": data["output1"].get("pbr", 0),
                     "per": data["output1"].get("per", 0),
@@ -316,7 +336,9 @@ class KISCollector(BaseCollector):
                 if attempt < 2:
                     time.sleep(2**attempt)
                 else:
-                    self.logger.error(f"[{stock_code}] Price query max retries exceeded")
+                    self.logger.error(
+                        f"[{stock_code}] Price query max retries exceeded"
+                    )
                     return None
             except Exception as e:
                 self.logger.error(f"[{stock_code}] Price query unexpected error: {e}")
@@ -373,6 +395,7 @@ class KISCollector(BaseCollector):
                             "stck_lwpr": [0],
                             "stck_oprc": [0],
                             "stck_clpr": [0],
+                            "stck_prpr": [0],
                             "eps": [0],
                             "pbr": [0],
                             "per": [0],

--- a/src/stockelper_kg/collectors/krx.py
+++ b/src/stockelper_kg/collectors/krx.py
@@ -63,5 +63,7 @@ class KRXCollector(BaseCollector):
             }
         )
 
+        df["corp_name"] = df["stock_nm"]
+
         self.logger.info(f"Collected {len(df)} companies from KRX")
         return df

--- a/src/stockelper_kg/collectors/mongodb.py
+++ b/src/stockelper_kg/collectors/mongodb.py
@@ -41,6 +41,9 @@ class MongoDBCollector(BaseCollector):
             data = list(documents)
 
             if data:
+                self.logger.info(f"Found {len(data)} documents in MongoDB")
+                self.logger.debug(f"Sample document: {data[0]}")
+
                 competitor_df = pd.DataFrame(data)
                 self.logger.info("Converted MongoDB to competitor_df")
                 competitor_df = competitor_df.rename(columns={"_id": "stock_code"})
@@ -68,7 +71,9 @@ class MongoDBCollector(BaseCollector):
 
         except Exception as e:
             self.logger.error(f"Failed to connect to DB: {e}")
-            self.logger.info("Using empty competitor DataFrame due to connection failure")
+            self.logger.info(
+                "Using empty competitor DataFrame due to connection failure"
+            )
             return pd.DataFrame(columns=["stock_code", "compete_code_li"])
         finally:
             try:

--- a/src/stockelper_kg/collectors/orchestrator.py
+++ b/src/stockelper_kg/collectors/orchestrator.py
@@ -1,11 +1,11 @@
-"""Data collection orchestrator."""
+"""Legacy batch data collection orchestrator."""
 
 import logging
+from typing import List
 
 import pandas as pd
 
 from ..config import Config
-from ..utils import measure_time
 from .dart import DartCollector
 from .kis import KISCollector
 from .krx import KRXCollector
@@ -15,9 +15,13 @@ logger = logging.getLogger(__name__)
 
 
 class DataOrchestrator:
-    """Orchestrates data collection from multiple sources."""
+    """Orchestrates batch data collection (legacy mode).
 
-    def __init__(self, config: Config, date_list: list, env_path: str = ".env"):
+    This class collects all data for all stocks in batch mode,
+    then returns a merged DataFrame for graph building.
+    """
+
+    def __init__(self, config: Config, date_list: List[str], env_path: str = ".env"):
         """Initialize data orchestrator.
 
         Args:
@@ -27,87 +31,65 @@ class DataOrchestrator:
         """
         self.config = config
         self.date_list = date_list
+        self.env_path = env_path
+
+        # Initialize collectors
         self.krx_collector = KRXCollector(config.sleep_seconds)
         self.kis_collector = KISCollector(config.kis, config.sleep_seconds, env_path)
         self.dart_collector = DartCollector(config.dart_api_key, config.sleep_seconds)
         self.mongodb_collector = MongoDBCollector(config.mongodb)
 
-        self.company_df = None
-        self.price_df = None
-        self.competitor_df = None
-        self.fs_df = None
-        self.total_df = None
-
-    @measure_time
-    def collect_company_info(self):
-        """Collect company information from KRX and KIS."""
-        logger.info("[1. Collecting company info...]")
-        company_df_krx = self.krx_collector.collect()
-        stock_codes = company_df_krx["stock_code"].tolist()
-
-        company_df_kis, _ = self.kis_collector.collect(stock_codes, [])
-        self.company_df = pd.merge(
-            company_df_krx, company_df_kis, how="left", on="stock_code"
-        )
-
-    @measure_time
-    def collect_price_info(self):
-        """Collect price and indicator information."""
-        logger.info("[2. Collecting price info...]")
-        stock_codes = self.company_df["stock_code"].tolist()
-        _, self.price_df = self.kis_collector.collect(stock_codes, self.date_list)
-
-    @measure_time
-    def collect_competitor_info(self):
-        """Collect competitor information from MongoDB."""
-        logger.info("[3. Collecting competitor info...]")
-        self.competitor_df = self.mongodb_collector.collect()
-
-        stock_codes = self.company_df["stock_code"].tolist()
-        existing_stock_codes = (
-            set(self.competitor_df["stock_code"])
-            if not self.competitor_df.empty
-            else set()
-        )
-
-        missing_stock_codes = set(stock_codes) - existing_stock_codes
-        for stock_code in missing_stock_codes:
-            missing_row = pd.DataFrame(
-                {"stock_code": [stock_code], "compete_code_li": [[]]}
-            )
-            self.competitor_df = pd.concat(
-                [self.competitor_df, missing_row], ignore_index=True
-            )
-
-    @measure_time
-    def collect_financial_statements(self):
-        """Collect financial statement information."""
-        logger.info("[4. Collecting financial statements...]")
-        stock_codes = self.company_df["stock_code"].tolist()
-        date = self.date_list[0]
-        self.fs_df = self.dart_collector.collect(stock_codes, date)
-
-    def create_total_df(self) -> pd.DataFrame:
-        """Merge all collected data into single DataFrame.
-
-        Returns:
-            Combined DataFrame with all data
-        """
-        logger.info("[5. Creating total DataFrame...]")
-        self.total_df = pd.merge(self.company_df, self.price_df, on="stock_code", how="left")
-        self.total_df = pd.merge(self.total_df, self.competitor_df, on="stock_code", how="left")
-        self.total_df = pd.merge(self.total_df, self.fs_df, on="stock_code", how="left")
-        return self.total_df
-
-    @measure_time
     def run_all(self) -> pd.DataFrame:
-        """Run all data collection steps.
+        """Collect all data for all stocks and return merged DataFrame.
 
         Returns:
-            Combined DataFrame with all collected data
+            Merged DataFrame with all stock data
         """
-        self.collect_company_info()
-        self.collect_price_info()
-        self.collect_competitor_info()
-        self.collect_financial_statements()
-        return self.create_total_df()
+        logger.info("[orchestrator] Start batch data collection (legacy mode)")
+
+        # Step 1: Collect static data (company info and competitors)
+        logger.info("[1/4] Collecting static data (company + competitors)")
+        company_df_krx = self.krx_collector.collect()
+        logger.info(
+            "[1/4] Collected company info from KRX: %d companies", len(company_df_krx)
+        )
+
+        competitor_df = self.mongodb_collector.collect()
+        logger.info("[1/4] Collected competitor data from MongoDB")
+
+        # Merge company and competitor data
+        static_df = pd.merge(company_df_krx, competitor_df, on="stock_code", how="left")
+        static_df["compete_code_li"] = static_df["compete_code_li"].apply(
+            lambda x: x if isinstance(x, list) else []
+        )
+
+        # Step 2: Get all stock codes
+        all_stock_codes = static_df["stock_code"].tolist()
+        logger.info("[orchestrator] Total stocks to process: %d", len(all_stock_codes))
+
+        # Step 3: Collect KIS data (company info + price) for all stocks
+        logger.info("[2/4] Collecting KIS data (company info + price)")
+        company_df_kis, price_df = self.kis_collector.collect(
+            all_stock_codes, self.date_list
+        )
+        logger.info(
+            "[2/4] Collected KIS company data: %d companies", len(company_df_kis)
+        )
+
+        # Step 4: Collect financial statements for all stocks
+        logger.info("[3/4] Collecting financial statements from DART")
+        fs_df = self.dart_collector.collect(all_stock_codes, self.date_list[0])
+        logger.info("[3/4] Collected financial statements: %d companies", len(fs_df))
+
+        # Step 5: Merge all data
+        logger.info("[4/4] Merging all data")
+        result = pd.merge(static_df, company_df_kis, on="stock_code", how="left")
+        result = pd.merge(result, price_df, on="stock_code", how="left")
+        result = pd.merge(result, fs_df, on="stock_code", how="left")
+
+        logger.info(
+            "[orchestrator] Batch data collection completed, final rows: %d",
+            len(result),
+        )
+
+        return result

--- a/src/stockelper_kg/collectors/streaming_orchestrator.py
+++ b/src/stockelper_kg/collectors/streaming_orchestrator.py
@@ -1,7 +1,10 @@
 """Streaming data collection orchestrator with resume capability."""
 
 import logging
-from typing import List, Optional, Set
+import threading
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from threading import Lock
+from typing import List, Optional, Set, Tuple
 
 import pandas as pd
 from tqdm import tqdm
@@ -26,8 +29,8 @@ class StreamingOrchestrator:
         date_list: List[str],
         neo4j_client: Neo4jClient,
         env_path: str = ".env",
-        batch_size: int = 100,
         skip_existing: bool = True,
+        max_workers: Optional[int] = None,
     ):
         """Initialize streaming orchestrator.
 
@@ -36,16 +39,18 @@ class StreamingOrchestrator:
             date_list: List of dates to collect data for
             neo4j_client: Neo4j client for graph operations
             env_path: Path to .env file for token updates
-            batch_size: Number of stocks to process in each batch
             skip_existing: Skip stocks that already exist in database
+            max_workers: Maximum number of parallel workers. If None, processes
+                        sequentially. Recommended: 2-4 to avoid API rate limits.
         """
         self.config = config
         self.date_list = date_list
         self.neo4j_client = neo4j_client
-        self.batch_size = batch_size
         self.skip_existing = skip_existing
+        self.max_workers = max_workers
+        self.env_path = env_path
 
-        # Initialize collectors
+        # Initialize collectors (shared for sequential processing)
         self.krx_collector = KRXCollector(config.sleep_seconds)
         self.kis_collector = KISCollector(config.kis, config.sleep_seconds, env_path)
         self.dart_collector = DartCollector(config.dart_api_key, config.sleep_seconds)
@@ -54,9 +59,27 @@ class StreamingOrchestrator:
         # Initialize graph builder
         self.graph_builder = GraphBuilder(neo4j_client)
 
-        # Track processed stocks
+        # Track processed stocks (thread-safe)
         self.processed_stocks: Set[str] = set()
         self.failed_stocks: Set[str] = set()
+        self._lock = Lock()
+        self._thread_local = threading.local()
+
+    def _get_thread_collectors(self) -> Tuple[KISCollector, DartCollector]:
+        """Get or create thread-local collectors.
+
+        Returns:
+            Tuple of (KISCollector, DartCollector)
+        """
+        if not hasattr(self._thread_local, "kis_collector"):
+            self._thread_local.kis_collector = KISCollector(
+                self.config.kis, self.config.sleep_seconds, self.env_path
+            )
+        if not hasattr(self._thread_local, "dart_collector"):
+            self._thread_local.dart_collector = DartCollector(
+                self.config.dart_api_key, self.config.sleep_seconds
+            )
+        return self._thread_local.kis_collector, self._thread_local.dart_collector
 
     def get_stocks_to_process(self, all_stock_codes: List[str]) -> List[str]:
         """Get list of stocks that need to be processed.
@@ -99,12 +122,15 @@ class StreamingOrchestrator:
 
         # Get competitor info from MongoDB
         competitor_df = self.mongodb_collector.collect()
-        logger.info(f"Collected competitor data from MongoDB")
+        logger.info(f"Collected {len(competitor_df)} competitor records from MongoDB")
+        if not competitor_df.empty:
+            logger.debug(f"Competitor DF sample:\n{competitor_df.head(1)}")
 
         # Merge company and competitor data
-        static_df = pd.merge(
-            company_df_krx, competitor_df, on="stock_code", how="left"
-        )
+        static_df = pd.merge(company_df_krx, competitor_df, on="stock_code", how="left")
+
+        merged_count = static_df["compete_code_li"].notna().sum()
+        logger.info(f"Merged competitor data for {merged_count} companies")
 
         # Fill missing competitor data
         static_df["compete_code_li"] = static_df["compete_code_li"].apply(
@@ -113,75 +139,68 @@ class StreamingOrchestrator:
 
         return static_df
 
-    def process_stock_batch(
-        self, stock_codes: List[str], static_df: pd.DataFrame
-    ) -> tuple:
-        """Process a batch of stocks.
+    def _process_single_stock(
+        self, stock_code: str, static_df: pd.DataFrame
+    ) -> Tuple[bool, str]:
+        """Process a single stock.
 
         Args:
-            stock_codes: List of stock codes to process
+            stock_code: Stock code to process
             static_df: DataFrame with static company data
 
         Returns:
-            Tuple of (success_count, failed_count)
+            Tuple of (success: bool, stock_code: str)
         """
-        success_count = 0
-        failed_count = 0
+        try:
+            # Check if already processed (double check)
+            if self.skip_existing and self.neo4j_client.check_stock_exists(stock_code):
+                logger.debug(f"[{stock_code}] Already exists, skipping")
+                return True, stock_code
 
-        for stock_code in tqdm(stock_codes, desc="Processing batch"):
-            try:
-                # Check if already processed (double check)
-                if self.skip_existing and self.neo4j_client.check_stock_exists(
-                    stock_code
-                ):
-                    logger.debug(f"[{stock_code}] Already exists, skipping")
-                    continue
-
-                # Get static data for this stock
-                stock_static = static_df[static_df["stock_code"] == stock_code]
-                if stock_static.empty:
-                    logger.warning(f"[{stock_code}] No static data found")
-                    failed_count += 1
+            # Get static data for this stock
+            stock_static = static_df[static_df["stock_code"] == stock_code]
+            if stock_static.empty:
+                logger.warning(f"[{stock_code}] No static data found")
+                with self._lock:
                     self.failed_stocks.add(stock_code)
-                    continue
+                return False, stock_code
 
-                # Collect KIS data (company info + price)
-                company_df_kis, price_df = self.kis_collector.collect(
-                    [stock_code], self.date_list
-                )
+            # Get thread-local collectors (reused per thread)
+            kis_collector, dart_collector = self._get_thread_collectors()
 
-                # Collect financial statements
-                fs_df = self.dart_collector.collect([stock_code], self.date_list[0])
+            # Collect KIS data (company info + price)
+            company_df_kis, price_df = kis_collector.collect(
+                [stock_code], self.date_list
+            )
 
-                # Merge all data
-                stock_data = self._merge_stock_data(
-                    stock_static, company_df_kis, price_df, fs_df
-                )
+            # Collect financial statements
+            fs_df = dart_collector.collect([stock_code], self.date_list[0])
 
-                if stock_data.empty:
-                    logger.warning(f"[{stock_code}] Failed to merge data")
-                    failed_count += 1
+            # Merge all data
+            stock_data = self._merge_stock_data(
+                stock_static, company_df_kis, price_df, fs_df
+            )
+
+            if stock_data.empty:
+                logger.warning(f"[{stock_code}] Failed to merge data")
+                with self._lock:
                     self.failed_stocks.add(stock_code)
-                    continue
+                return False, stock_code
 
-                # Build and upload to Neo4j
-                self.graph_builder.build_graph(stock_data, stock_code, self.date_list)
+            # Build and upload to Neo4j
+            self.graph_builder.build_graph(stock_data, stock_code, self.date_list)
 
+            with self._lock:
                 self.processed_stocks.add(stock_code)
-                success_count += 1
 
-                logger.info(
-                    f"[{stock_code}] Successfully processed "
-                    f"({success_count}/{len(stock_codes)})"
-                )
+            logger.debug(f"[streaming][{stock_code}] Successfully processed")
+            return True, stock_code
 
-            except Exception as e:
-                logger.error(f"[{stock_code}] Error processing: {e}")
-                failed_count += 1
+        except Exception as e:
+            logger.error(f"[{stock_code}] Error processing: {e}")
+            with self._lock:
                 self.failed_stocks.add(stock_code)
-                continue
-
-        return success_count, failed_count
+            return False, stock_code
 
     def _merge_stock_data(
         self,
@@ -219,9 +238,12 @@ class StreamingOrchestrator:
         Returns:
             Dictionary with processing statistics
         """
-        logger.info("=" * 70)
-        logger.info("Starting streaming data collection with resume capability")
-        logger.info("=" * 70)
+        logger.info(
+            "[streaming] Starting data collection with resume capability "
+            "(skip_existing=%s, max_workers=%s)",
+            self.skip_existing,
+            self.max_workers,
+        )
 
         # Step 1: Collect static data
         static_df = self.collect_static_data()
@@ -239,42 +261,60 @@ class StreamingOrchestrator:
                 "failed": 0,
             }
 
-        # Step 3: Process in batches
+        # Step 3: Process all stocks
         total_success = 0
         total_failed = 0
 
-        for i in range(0, len(stocks_to_process), self.batch_size):
-            batch = stocks_to_process[i : i + self.batch_size]
-            batch_num = i // self.batch_size + 1
-            total_batches = (len(stocks_to_process) + self.batch_size - 1) // self.batch_size
+        logger.info(
+            "[streaming] Processing %d stocks (Parallel: %s)",
+            len(stocks_to_process),
+            self.max_workers is not None,
+        )
 
-            logger.info(f"\n{'=' * 70}")
-            logger.info(
-                f"Processing batch {batch_num}/{total_batches} "
-                f"({len(batch)} stocks)"
-            )
-            logger.info(f"{'=' * 70}")
+        if self.max_workers is None or self.max_workers <= 1:
+            # Sequential processing
+            for stock_code in tqdm(stocks_to_process, desc="Processing"):
+                success, _ = self._process_single_stock(stock_code, static_df)
+                if success:
+                    total_success += 1
+                else:
+                    total_failed += 1
+        else:
+            # Parallel processing with single ThreadPool
+            with ThreadPoolExecutor(max_workers=self.max_workers) as executor:
+                future_to_stock = {
+                    executor.submit(
+                        self._process_single_stock, stock_code, static_df
+                    ): stock_code
+                    for stock_code in stocks_to_process
+                }
 
-            success, failed = self.process_stock_batch(batch, static_df)
-            total_success += success
-            total_failed += failed
-
-            logger.info(
-                f"Batch {batch_num} complete: "
-                f"{success} success, {failed} failed"
-            )
+                for future in tqdm(
+                    as_completed(future_to_stock),
+                    total=len(stocks_to_process),
+                    desc="Processing",
+                ):
+                    success, _ = future.result()
+                    if success:
+                        total_success += 1
+                    else:
+                        total_failed += 1
 
         # Step 4: Summary
-        logger.info(f"\n{'=' * 70}")
-        logger.info("Streaming collection completed!")
-        logger.info(f"{'=' * 70}")
-        logger.info(f"Total stocks: {len(all_stock_codes)}")
-        logger.info(f"Processed: {total_success}")
-        logger.info(f"Skipped (existing): {len(all_stock_codes) - len(stocks_to_process)}")
-        logger.info(f"Failed: {total_failed}")
+        logger.info("[streaming] Streaming collection completed")
+        logger.info("[streaming] Total stocks: %d", len(all_stock_codes))
+        logger.info("[streaming] Processed: %d", total_success)
+        logger.info(
+            "[streaming] Skipped (existing): %d",
+            len(all_stock_codes) - len(stocks_to_process),
+        )
+        logger.info("[streaming] Failed: %d", total_failed)
 
         if self.failed_stocks:
-            logger.warning(f"Failed stocks: {sorted(self.failed_stocks)[:10]}...")
+            logger.warning(
+                "[streaming] Failed stocks (sample): %s",
+                sorted(self.failed_stocks)[:10],
+            )
 
         return {
             "total_stocks": len(all_stock_codes),
@@ -294,14 +334,18 @@ class StreamingOrchestrator:
         Returns:
             Dictionary with update statistics
         """
-        logger.info("=" * 70)
-        logger.info("Updating existing stocks with new dates")
-        logger.info("=" * 70)
+        logger.info(
+            "[streaming] Updating existing stocks with new dates "
+            "(provided_codes=%s)",
+            stock_codes is not None,
+        )
 
         # Get stocks to update
         if stock_codes is None:
             stock_codes = list(self.neo4j_client.get_processed_stocks())
-            logger.info(f"Found {len(stock_codes)} existing stocks to update")
+            logger.info(
+                "[streaming] Found %d existing stocks to update", len(stock_codes)
+            )
 
         total_updated = 0
         total_failed = 0
@@ -317,18 +361,25 @@ class StreamingOrchestrator:
                 new_dates = [d for d in self.date_list if d not in existing_dates]
 
                 if not new_dates:
-                    logger.debug(f"[{stock_code}] All dates already processed")
+                    logger.debug(
+                        "[streaming][%s] All dates already processed", stock_code
+                    )
                     continue
 
                 logger.info(
-                    f"[{stock_code}] Updating {len(new_dates)} new dates: {new_dates}"
+                    "[streaming][%s] Updating %d new dates: %s",
+                    stock_code,
+                    len(new_dates),
+                    new_dates,
                 )
 
                 # Collect price data for new dates only
                 _, price_df = self.kis_collector.collect([stock_code], new_dates)
 
                 if price_df.empty:
-                    logger.warning(f"[{stock_code}] No price data collected")
+                    logger.warning(
+                        "[streaming][%s] No price data collected", stock_code
+                    )
                     total_failed += 1
                     continue
 
@@ -344,16 +395,17 @@ class StreamingOrchestrator:
                 )
 
                 total_updated += 1
-                logger.info(f"[{stock_code}] Successfully updated")
+                logger.info("[streaming][%s] Successfully updated", stock_code)
 
             except Exception as e:
-                logger.error(f"[{stock_code}] Error updating: {e}")
+                logger.error("[streaming][%s] Error updating: %s", stock_code, e)
                 total_failed += 1
                 continue
 
-        logger.info(f"\n{'=' * 70}")
-        logger.info("Update completed!")
-        logger.info(f"Updated: {total_updated}, Failed: {total_failed}")
-        logger.info(f"{'=' * 70}")
+        logger.info(
+            "[streaming] Update completed (updated=%d, failed=%d)",
+            total_updated,
+            total_failed,
+        )
 
         return {"updated": total_updated, "failed": total_failed}

--- a/src/stockelper_kg/config.py
+++ b/src/stockelper_kg/config.py
@@ -1,10 +1,13 @@
 """Configuration management for Stockelper KG."""
 
 import os
+import logging
 from dataclasses import dataclass
 from typing import Optional
 
 from dotenv import load_dotenv
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass
@@ -61,7 +64,10 @@ class Config:
         Raises:
             ValueError: If required environment variables are missing
         """
-        load_dotenv(dotenv_path=env_path)
+        try:
+            load_dotenv(dotenv_path=env_path)
+        except OSError as exc:
+            logger.warning("Skipping .env load during config init: %s", exc)
 
         # Neo4j
         neo4j = Neo4jConfig(

--- a/src/stockelper_kg/event_cli.py
+++ b/src/stockelper_kg/event_cli.py
@@ -1,0 +1,213 @@
+"""CLI entry point for the news/event pipeline."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Optional
+
+from .config import Config
+from .graph import Neo4jClient
+from .pipeline import EventPipeline
+
+logging.basicConfig(
+    level=logging.INFO, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+)
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class EventInput:
+    """Container for a single event text and its metadata."""
+
+    identifier: str
+    text: str
+    metadata: Dict[str, Any]
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Classify news events and upsert them into Neo4j."
+    )
+    src = parser.add_mutually_exclusive_group(required=True)
+    src.add_argument("--file", type=str, help="Path to a single text file")
+    src.add_argument(
+        "--dir",
+        dest="directory",
+        type=str,
+        help="Directory containing *.txt files (recursive)",
+    )
+    src.add_argument(
+        "--dataset",
+        type=str,
+        help="JSONL dataset where each line is an event record",
+    )
+    parser.add_argument(
+        "--env",
+        type=str,
+        default=".env",
+        help="Path to the .env file with API/DB credentials (default: .env)",
+    )
+    return parser
+
+
+def _read_text_file(path: Path) -> str:
+    if not path.is_file():
+        raise FileNotFoundError(f"File not found: {path}")
+    return path.read_text(encoding="utf-8")
+
+
+def _collect_from_file(path_str: str) -> List[EventInput]:
+    path = Path(path_str).expanduser().resolve()
+    text = _read_text_file(path)
+    meta = {"source": "file", "path": str(path), "filename": path.name}
+    return [EventInput(str(path), text, meta)]
+
+
+def _collect_from_directory(dir_str: str) -> List[EventInput]:
+    root = Path(dir_str).expanduser().resolve()
+    if not root.is_dir():
+        raise FileNotFoundError(f"Directory not found: {root}")
+    files = sorted(p for p in root.rglob("*.txt") if p.is_file())
+    if not files:
+        raise ValueError(f"No *.txt files found under {root}")
+    inputs: List[EventInput] = []
+    for path in files:
+        text = _read_text_file(path)
+        meta = {"source": "dir", "path": str(path), "filename": path.name}
+        inputs.append(EventInput(str(path), text, meta))
+    return inputs
+
+
+def _collect_from_dataset(dataset_str: str) -> List[EventInput]:
+    dataset_path = Path(dataset_str).expanduser().resolve()
+    if not dataset_path.is_file():
+        raise FileNotFoundError(f"Dataset not found: {dataset_path}")
+
+    inputs: List[EventInput] = []
+    with dataset_path.open("r", encoding="utf-8") as handle:
+        for idx, raw_line in enumerate(handle, start=1):
+            line = raw_line.strip()
+            if not line:
+                continue
+            try:
+                record = json.loads(line)
+            except json.JSONDecodeError as exc:
+                raise ValueError(
+                    f"{dataset_path}:{idx} is not valid JSON: {exc}"
+                ) from exc
+
+            text = record.get("content") or record.get("text")
+            content_file = record.get("content_file")
+            if not text and content_file:
+                file_path = Path(content_file)
+                if not file_path.is_absolute():
+                    file_path = (dataset_path.parent / file_path).resolve()
+                text = _read_text_file(file_path)
+            if not text:
+                raise ValueError(
+                    f"{dataset_path}:{idx} missing 'content' or 'content_file'."
+                )
+
+            extra_meta: Dict[str, Any] = {}
+            if isinstance(record.get("metadata"), dict):
+                extra_meta.update(record["metadata"])
+            for key, value in record.items():
+                if key in {"content", "content_file", "metadata", "text"}:
+                    continue
+                extra_meta.setdefault(key, value)
+            if content_file:
+                extra_meta.setdefault("content_file", content_file)
+
+            identifier = (
+                record.get("description")
+                or record.get("url")
+                or f"{dataset_path.name}:{idx}"
+            )
+
+            inputs.append(EventInput(str(identifier), text, extra_meta))
+
+    if not inputs:
+        raise ValueError(f"{dataset_path} did not yield any records.")
+    return inputs
+
+
+def _collect_inputs(args: argparse.Namespace) -> List[EventInput]:
+    if args.file:
+        return _collect_from_file(args.file)
+    if getattr(args, "directory", None):
+        return _collect_from_directory(args.directory)
+    if args.dataset:
+        return _collect_from_dataset(args.dataset)
+    return []
+
+
+def _run_pipeline(
+    pipeline: EventPipeline, items: List[EventInput]
+) -> List[Dict[str, Any]]:
+    results: List[Dict[str, Any]] = []
+    total = len(items)
+    for idx, item in enumerate(items, start=1):
+        logger.info("[%d/%d] Processing %s", idx, total, item.identifier)
+        try:
+            event_data = pipeline.process(item.text, metadata=item.metadata)
+            event_type = event_data.get("event_type", "UNKNOWN")
+            logger.info("[%s] ✓ event_type=%s", item.identifier, event_type)
+            results.append(
+                {
+                    "source": item.identifier,
+                    "success": True,
+                    "event_type": event_type,
+                    "metadata": item.metadata,
+                    "result": event_data,
+                }
+            )
+        except Exception as exc:
+            logger.exception("[%s] ✗ processing failed", item.identifier)
+            results.append(
+                {
+                    "source": item.identifier,
+                    "success": False,
+                    "metadata": item.metadata,
+                    "error": str(exc),
+                }
+            )
+    return results
+
+
+def cli(argv: Optional[Iterable[str]] = None) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(list(argv) if argv is not None else None)
+
+    inputs = _collect_inputs(args)
+    if not inputs:
+        parser.error("No inputs were collected. Check your arguments.")
+
+    config = Config.from_env(args.env)
+    setattr(config, "env_path", args.env)
+
+    client: Optional[Neo4jClient] = None
+    try:
+        client = Neo4jClient(config.neo4j)
+        client.ensure_constraints()
+        pipeline = EventPipeline(config, client)
+        report_rows = _run_pipeline(pipeline, inputs)
+    finally:
+        if client:
+            client.close()
+
+    failures = [row for row in report_rows if not row.get("success")]
+    if failures:
+        failed_sources = ", ".join(row["source"] for row in failures)
+        logger.error("Processing completed with failures: %s", failed_sources)
+        raise SystemExit(1)
+
+    logger.info("All events processed successfully.")
+    return 0
+
+
+if __name__ == "__main__":
+    cli()

--- a/src/stockelper_kg/event_cli.py
+++ b/src/stockelper_kg/event_cli.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import argparse
-import json
 import logging
 from dataclasses import dataclass
 from pathlib import Path
@@ -39,11 +38,6 @@ def _build_parser() -> argparse.ArgumentParser:
         dest="directory",
         type=str,
         help="Directory containing *.txt files (recursive)",
-    )
-    src.add_argument(
-        "--dataset",
-        type=str,
-        help="JSONL dataset where each line is an event record",
     )
     parser.add_argument(
         "--env",
@@ -82,66 +76,11 @@ def _collect_from_directory(dir_str: str) -> List[EventInput]:
     return inputs
 
 
-def _collect_from_dataset(dataset_str: str) -> List[EventInput]:
-    dataset_path = Path(dataset_str).expanduser().resolve()
-    if not dataset_path.is_file():
-        raise FileNotFoundError(f"Dataset not found: {dataset_path}")
-
-    inputs: List[EventInput] = []
-    with dataset_path.open("r", encoding="utf-8") as handle:
-        for idx, raw_line in enumerate(handle, start=1):
-            line = raw_line.strip()
-            if not line:
-                continue
-            try:
-                record = json.loads(line)
-            except json.JSONDecodeError as exc:
-                raise ValueError(
-                    f"{dataset_path}:{idx} is not valid JSON: {exc}"
-                ) from exc
-
-            text = record.get("content") or record.get("text")
-            content_file = record.get("content_file")
-            if not text and content_file:
-                file_path = Path(content_file)
-                if not file_path.is_absolute():
-                    file_path = (dataset_path.parent / file_path).resolve()
-                text = _read_text_file(file_path)
-            if not text:
-                raise ValueError(
-                    f"{dataset_path}:{idx} missing 'content' or 'content_file'."
-                )
-
-            extra_meta: Dict[str, Any] = {}
-            if isinstance(record.get("metadata"), dict):
-                extra_meta.update(record["metadata"])
-            for key, value in record.items():
-                if key in {"content", "content_file", "metadata", "text"}:
-                    continue
-                extra_meta.setdefault(key, value)
-            if content_file:
-                extra_meta.setdefault("content_file", content_file)
-
-            identifier = (
-                record.get("description")
-                or record.get("url")
-                or f"{dataset_path.name}:{idx}"
-            )
-
-            inputs.append(EventInput(str(identifier), text, extra_meta))
-
-    if not inputs:
-        raise ValueError(f"{dataset_path} did not yield any records.")
-    return inputs
-
-
 def _collect_inputs(args: argparse.Namespace) -> List[EventInput]:
     if args.file:
         return _collect_from_file(args.file)
     if getattr(args, "directory", None):
         return _collect_from_directory(args.directory)
-    if args.dataset:
-        return _collect_from_dataset(args.dataset)
     return []
 
 

--- a/src/stockelper_kg/graph/__init__.py
+++ b/src/stockelper_kg/graph/__init__.py
@@ -1,12 +1,55 @@
-"""Neo4j graph database modules."""
+"""Neo4j graph database modules with lazy imports."""
 
-from .builder import GraphBuilder
-from .client import Neo4jClient
-from .queries import create_competitor_query, create_stock_query
+from __future__ import annotations
+
+from typing import Any
 
 __all__ = [
     "Neo4jClient",
     "GraphBuilder",
-    "create_stock_query",
-    "create_competitor_query",
+    "GraphPayload",
+    "GraphNodeSpec",
+    "GraphEdgeSpec",
+    "build_graph_payload",
+    "build_stock_snapshot_payload",
+    "build_competitor_payload",
+    "payload_to_cypher",
+    "generate_constraints",
 ]
+
+
+def __getattr__(name: str) -> Any:
+    """Lazily resolve submodules to avoid importing heavy dependencies."""
+    if name == "GraphBuilder":
+        from .builder import GraphBuilder
+
+        return GraphBuilder
+
+    if name == "Neo4jClient":
+        from .client import Neo4jClient
+
+        return Neo4jClient
+
+    if name in (
+        "GraphPayload",
+        "GraphNodeSpec",
+        "GraphEdgeSpec",
+        "build_graph_payload",
+        "build_stock_snapshot_payload",
+        "build_competitor_payload",
+    ):
+        from . import payload
+
+        return getattr(payload, name)
+
+    if name == "payload_to_cypher":
+        from .cypher import payload_to_cypher
+
+        return payload_to_cypher
+
+    if name == "generate_constraints":
+        from .cypher import generate_constraints
+
+        return generate_constraints
+
+    raise AttributeError(f"module 'stockelper_kg.graph' has no attribute '{name}'")

--- a/src/stockelper_kg/graph/builder.py
+++ b/src/stockelper_kg/graph/builder.py
@@ -1,18 +1,63 @@
 """Graph database builder."""
 
+from __future__ import annotations
+
+import json
 import logging
-from typing import List
+import math
+from datetime import date as date_cls, datetime as datetime_cls
+from typing import Any, Dict, Iterable, List, Tuple
 
 import pandas as pd
 
 from .client import Neo4jClient
-from .queries import create_competitor_query, create_stock_query
+from .cypher import payload_to_cypher
+from .payload import build_competitor_payload, build_stock_snapshot_payload
+from ..utils.dates import normalize_date
 
 logger = logging.getLogger(__name__)
 
 
 class GraphBuilder:
     """Builds knowledge graph from collected data."""
+
+    COMPANY_FIELDS: Tuple[str, ...] = (
+        "stock_code",
+        "stock_nm",
+        "stock_abbrv",
+        "stock_nm_eng",
+        "listing_dt",
+        "market_nm",
+        "outstanding_shares",
+        "kospi200_item_yn",
+        "capital_stock",
+        "corp_code",
+        "corp_name",
+        "corp_cls",
+        "std_idst_clsf_cd_name",
+    )
+    PRICE_FIELDS: Tuple[str, ...] = (
+        "stock_code",
+        "stck_hgpr",
+        "stck_lwpr",
+        "stck_oprc",
+        "stck_clpr",
+        "stck_prpr",
+    )
+    FINANCIAL_FIELDS: Tuple[str, ...] = (
+        "stock_code",
+        "revenue",
+        "operating_income",
+        "net_income",
+        "total_assets",
+        "total_liabilities",
+        "total_equity",
+        "capital_stock",
+        "year",
+        "quarter",
+        "reported_date",
+    )
+    INDICATOR_FIELDS: Tuple[str, ...] = ("stock_code", "eps", "pbr", "per")
 
     def __init__(self, client: Neo4jClient):
         """Initialize graph builder.
@@ -25,41 +70,66 @@ class GraphBuilder:
     def build_stock_data(
         self, graph_df: pd.DataFrame, stock_code: str, dates: List[str]
     ) -> List[str]:
-        """Build Cypher queries for stock data.
-
-        Args:
-            graph_df: DataFrame with all collected data
-            stock_code: Stock code to build data for
-            dates: List of dates to build data for
-
-        Returns:
-            List of Cypher queries
-        """
-        queries = []
+        """Build Cypher queries for stock data."""
+        queries: List[str] = []
         filter_df = graph_df[graph_df["stock_code"] == stock_code]
 
         if filter_df.empty:
             logger.warning(f"No data found for stock_code: {stock_code}")
             return queries
 
-        company_dict = filter_df.iloc[0].to_dict()
+        base_record = filter_df.iloc[0].to_dict()
+        company_props = self._prepare_company_properties(base_record)
+        financials = self._extract_financials(base_record)
 
-        for date in dates:
+        normalized_dates = [d for d in (normalize_date(value) for value in dates) if d]
+        if not normalized_dates:
+            logger.warning(
+                "No valid dates supplied for %s; skipping snapshot generation",
+                stock_code,
+            )
+            return queries
+
+        if "date" not in filter_df.columns:
+            logger.warning(
+                "Input dataframe for %s has no 'date' column; cannot align price data",
+                stock_code,
+            )
+            return queries
+
+        normalized_date_series = filter_df["date"].apply(normalize_date)
+
+        for date in normalized_dates:
             try:
-                date_df = filter_df[filter_df["date"] == date]
+                date_df = filter_df[normalized_date_series == date]
                 if date_df.empty:
                     logger.warning(
-                        f"No data for {company_dict.get('stock_nm', stock_code)} "
+                        f"No data for {company_props.get('stock_nm', stock_code)} "
                         f"({stock_code}) on date {date}"
                     )
                     continue
 
-                stock_price_dict = date_df.iloc[0].to_dict()
-                query = create_stock_query(date, company_dict, stock_price_dict)
-                queries.append(query)
-            except Exception as e:
+                snapshot_record = date_df.iloc[0].to_dict()
+                stock_price = self._select_fields(snapshot_record, self.PRICE_FIELDS)
+                stock_price.setdefault("stock_code", stock_code)
+                stock_price["traded_at"] = date
+                stock_price["date"] = date
+                stock_price = self._align_price_fields(stock_price)
+
+                indicators = self._extract_indicators(snapshot_record, date)
+                fs_snapshot = self._prepare_financial_snapshot(financials, date)
+
+                payload = build_stock_snapshot_payload(
+                    company=company_props,
+                    date=date,
+                    stock_price=stock_price,
+                    financials=fs_snapshot,
+                    indicators=indicators,
+                )
+                queries.append(payload_to_cypher(payload))
+            except Exception as exc:
                 logger.error(
-                    f"Error creating stock query for {stock_code} on {date}: {e}"
+                    f"Error creating stock payload for {stock_code} on {date}: {exc}"
                 )
 
         return queries
@@ -67,71 +137,187 @@ class GraphBuilder:
     def build_competitor_data(
         self, graph_df: pd.DataFrame, stock_code: str
     ) -> List[str]:
-        """Build Cypher queries for competitor relationships.
-
-        Args:
-            graph_df: DataFrame with all collected data
-            stock_code: Stock code to build competitor data for
-
-        Returns:
-            List of Cypher queries
-        """
-        queries = []
+        """Build Cypher queries for competitor relationships."""
+        queries: List[str] = []
 
         try:
             src_df = graph_df[graph_df["stock_code"] == stock_code]
             if src_df.empty:
                 return queries
 
-            src_company_dict = src_df.iloc[0].to_dict()
-            compete_code_list = src_df["compete_code_li"].values[0]
+            src_company = self._prepare_company_properties(src_df.iloc[0].to_dict())
+            compete_code_list = self._extract_competitors(src_df)
 
             if not compete_code_list:
                 return queries
 
-            for compete_stock_code in compete_code_list:
-                # Skip self-reference
-                if stock_code == compete_stock_code:
+            for target_code in compete_code_list:
+                if stock_code == target_code:
                     continue
 
-                dst_df = graph_df[graph_df["stock_code"] == compete_stock_code]
+                dst_df = graph_df[graph_df["stock_code"] == target_code]
                 if dst_df.empty:
-                    logger.warning(
-                        f"Competitor {compete_stock_code} not found in data"
-                    )
+                    logger.warning(f"Competitor {target_code} not found in data")
                     continue
 
-                dst_company_dict = dst_df.iloc[0].to_dict()
-                query = create_competitor_query(src_company_dict, dst_company_dict)
-                queries.append(query)
+                dst_company = self._prepare_company_properties(dst_df.iloc[0].to_dict())
 
-        except Exception as e:
-            logger.error(f"Error creating competitor queries for {stock_code}: {e}")
+                payload = build_competitor_payload(src_company, dst_company)
+                queries.append(payload_to_cypher(payload))
+
+        except Exception as exc:
+            logger.error(f"Error creating competitor queries for {stock_code}: {exc}")
 
         return queries
 
     def build_graph(self, graph_df: pd.DataFrame, stock_code: str, dates: List[str]):
-        """Build complete graph for a stock.
-
-        Args:
-            graph_df: DataFrame with all collected data
-            stock_code: Stock code to build graph for
-            dates: List of dates to build data for
-        """
+        """Build complete graph for a stock."""
         try:
             queries = []
+            queries.extend(self.build_stock_data(graph_df, stock_code, dates))
+            queries.extend(self.build_competitor_data(graph_df, stock_code))
 
-            # Build stock data queries
-            stock_queries = self.build_stock_data(graph_df, stock_code, dates)
-            queries.extend(stock_queries)
-
-            # Build competitor queries
-            competitor_queries = self.build_competitor_data(graph_df, stock_code)
-            queries.extend(competitor_queries)
-
-            # Execute all queries in single transaction
             if queries:
                 self.client.execute_queries(queries)
 
-        except Exception as e:
-            logger.error(f"Error building graph for {stock_code}: {e}")
+        except Exception as exc:
+            logger.error(f"Error building graph for {stock_code}: {exc}")
+
+    def _select_fields(
+        self, record: Dict[str, Any], fields: Iterable[str]
+    ) -> Dict[str, Any]:
+        """Select and sanitise a subset of fields from a record."""
+        result: Dict[str, Any] = {}
+        for key in fields:
+            if key not in record:
+                continue
+            value = self._normalise_value(record[key])
+            if value is None:
+                continue
+            result[key] = value
+        return result
+
+    def _prepare_company_properties(self, record: Dict[str, Any]) -> Dict[str, Any]:
+        """Ensure Company nodes carry consistent identity properties."""
+        props = self._select_fields(record, self.COMPANY_FIELDS)
+        candidates = (
+            props.get("corp_name"),
+            record.get("corp_name"),
+            props.get("stock_nm"),
+            record.get("stock_nm"),
+            props.get("stock_abbrv"),
+            record.get("stock_abbrv"),
+        )
+        fallback_name = next((val for val in candidates if val), None)
+        normalised_name = self._normalise_value(fallback_name)
+        if normalised_name:
+            props.setdefault("corp_name", normalised_name)
+            props.setdefault("stock_nm", normalised_name)
+        return props
+
+    def _align_price_fields(self, price: Dict[str, Any]) -> Dict[str, Any]:
+        """Ensure both legacy and canonical price keys are present."""
+        if "stck_prpr" not in price and (close := price.get("stck_clpr")) is not None:
+            price["stck_prpr"] = close
+        if "stck_clpr" not in price and (present := price.get("stck_prpr")) is not None:
+            price["stck_clpr"] = present
+        return price
+
+    def _normalise_value(self, value: Any) -> Any:
+        """Normalise pandas/numpy-friendly values into JSON-safe scalars."""
+        if value is None:
+            return None
+        try:
+            if pd.isna(value):
+                return None
+        except Exception:
+            pass
+        if isinstance(value, float) and math.isnan(value):
+            return None
+        if isinstance(value, pd.Timestamp):
+            return value.strftime("%Y-%m-%d")
+        if isinstance(value, (datetime_cls, date_cls)):
+            return value.isoformat()
+        if hasattr(value, "item") and not isinstance(value, (bytes, str)):
+            try:
+                return value.item()
+            except Exception:
+                pass
+        if isinstance(value, (pd.Series, pd.DataFrame)):
+            return None
+        return value
+
+    def _extract_financials(self, record: Dict[str, Any]) -> Dict[str, Any] | None:
+        """Extract financial statement properties."""
+        data = self._select_fields(record, self.FINANCIAL_FIELDS)
+        if not data:
+            return None
+
+        if "stock_code" not in data and record.get("stock_code"):
+            data["stock_code"] = self._normalise_value(record["stock_code"])
+
+        fiscal_year = data.pop("year", None)
+        fiscal_period = data.pop("quarter", None)
+        if fiscal_year is not None:
+            data["fiscal_year"] = fiscal_year
+        if fiscal_period is not None:
+            data["fiscal_period"] = str(fiscal_period)
+        return data
+
+    def _extract_indicators(
+        self, record: Dict[str, Any], as_of: str
+    ) -> Dict[str, Any] | None:
+        """Extract indicator metrics for the given snapshot."""
+        data = self._select_fields(record, self.INDICATOR_FIELDS)
+        if not data:
+            return None
+        if "stock_code" not in data and record.get("stock_code"):
+            data["stock_code"] = self._normalise_value(record["stock_code"])
+        canonical = normalize_date(as_of)
+        if canonical:
+            data["as_of"] = canonical
+            data["date"] = canonical
+        return data
+
+    def _extract_competitors(self, df: pd.DataFrame) -> List[str]:
+        """Return a normalised list of competitor stock codes."""
+        if df.empty or "compete_code_li" not in df.columns:
+            return []
+
+        raw_value = df["compete_code_li"].iloc[0]
+
+        # Handle None/NaN
+        if raw_value is None or (isinstance(raw_value, float) and pd.isna(raw_value)):
+            return []
+
+        # Already a list
+        if isinstance(raw_value, list):
+            return [str(code).strip() for code in raw_value if code]
+
+        # JSON string -> list
+        if isinstance(raw_value, str):
+            try:
+                parsed = json.loads(raw_value)
+                if isinstance(parsed, list):
+                    return [str(code).strip() for code in parsed if code]
+            except (json.JSONDecodeError, ValueError):
+                pass
+
+        return []
+
+    def _prepare_financial_snapshot(
+        self, financials: Dict[str, Any] | None, as_of: str
+    ) -> Dict[str, Any] | None:
+        """Attach a reporting date to financial statements per snapshot."""
+        if not financials:
+            return None
+        snapshot = dict(financials)
+        explicit_reported = normalize_date(snapshot.get("reported_date"))
+        canonical_as_of = normalize_date(as_of)
+        reported = explicit_reported or canonical_as_of
+        if reported:
+            snapshot["reported_date"] = reported
+        effective_date = snapshot.get("reported_date") or canonical_as_of
+        if effective_date:
+            snapshot["date"] = effective_date
+        return snapshot

--- a/src/stockelper_kg/graph/client.py
+++ b/src/stockelper_kg/graph/client.py
@@ -1,189 +1,97 @@
-"""Neo4j database client."""
-
 import logging
-from typing import List
 
 from neo4j import GraphDatabase
+from neo4j.exceptions import ClientError, DatabaseError
 
 from ..config import Neo4jConfig
+from .cypher import generate_constraints
 
 logger = logging.getLogger(__name__)
 
 
 class Neo4jClient:
-    """Neo4j database client for knowledge graph operations."""
-
     def __init__(self, config: Neo4jConfig):
-        """Initialize Neo4j client.
-
-        Args:
-            config: Neo4j configuration
-        """
-        self.config = config
         self.driver = GraphDatabase.driver(
             config.uri, auth=(config.user, config.password)
         )
         logger.info(f"Connected to Neo4j at {config.uri}")
 
     def close(self):
-        """Close database connection."""
         self.driver.close()
         logger.info("Neo4j connection closed")
 
     def ensure_constraints(self):
-        """Create database constraints if they don't exist."""
-        with self.driver.session() as session:
-            session.execute_write(self._create_constraints)
-        logger.info("Database constraints ensured")
-
-    @staticmethod
-    def _create_constraints(tx):
-        """Create unique constraints on nodes.
-
-        Args:
-            tx: Neo4j transaction
-        """
-        tx.run(
-            "CREATE CONSTRAINT IF NOT EXISTS FOR (c:Company) "
-            "REQUIRE c.stock_code IS UNIQUE"
-        )
-        tx.run(
-            "CREATE CONSTRAINT IF NOT EXISTS FOR (s:Stock) "
-            "REQUIRE s.stock_code IS UNIQUE"
-        )
-        tx.run(
-            "CREATE CONSTRAINT IF NOT EXISTS FOR (d:Date) " "REQUIRE d.date IS UNIQUE"
-        )
-
-    def execute_query(self, cypher_query: str):
-        """Execute a single Cypher query.
-
-        Args:
-            cypher_query: Cypher query string
-        """
-        with self.driver.session() as session:
-            session.execute_write(self._run_query, cypher_query)
-
-    @staticmethod
-    def _run_query(tx, query: str):
-        """Run a Cypher query in transaction.
-
-        Args:
-            tx: Neo4j transaction
-            query: Cypher query string
-        """
-        tx.run(query)
-
-    def execute_queries(self, queries: List[str]):
-        """Execute multiple Cypher queries in a single transaction.
-
-        Args:
-            queries: List of Cypher query strings
-        """
-        if not queries:
+        constraints = generate_constraints()
+        if not constraints:
             return
 
         with self.driver.session() as session:
-            session.execute_write(self._run_queries, queries)
+            for statement in constraints.rstrip(";").split(";\n"):
+                if not statement.strip():
+                    continue
+                try:
+                    session.run(statement)
+                except (ClientError, DatabaseError) as exc:
+                    if exc.code == "Neo.ClientError.Schema.IndexAlreadyExists":
+                        continue
+                    if exc.code == "Neo.DatabaseError.Schema.ConstraintCreationFailed":
+                        if "NODE KEY" in str(exc) or "Node Key" in str(exc):
+                            continue
+                    raise
 
-    @staticmethod
-    def _run_queries(tx, queries: List[str]):
-        """Run multiple Cypher queries in transaction.
+    def execute_query(self, query: str):
+        with self.driver.session() as session:
+            session.execute_write(lambda tx: tx.run(query))
 
-        Args:
-            tx: Neo4j transaction
-            queries: List of Cypher query strings
-        """
-        for query in queries:
-            tx.run(query)
+    def execute_queries(self, queries: list[str]):
+        if not queries:
+            return
+        with self.driver.session() as session:
+            session.execute_write(lambda tx: [tx.run(q) for q in queries])
 
     def delete_all_data(self):
-        """Delete all nodes and relationships from database."""
         with self.driver.session() as session:
-            session.execute_write(self._delete_all)
+            session.execute_write(lambda tx: tx.run("MATCH (n) DETACH DELETE n"))
         logger.warning("All data deleted from Neo4j database")
 
-    @staticmethod
-    def _delete_all(tx):
-        """Delete all nodes and relationships.
-
-        Args:
-            tx: Neo4j transaction
-        """
-        tx.run("MATCH (n) DETACH DELETE n")
-
     def get_node_count(self) -> int:
-        """Get total number of nodes in database.
-
-        Returns:
-            Total node count
-        """
-        query = "MATCH (n) RETURN count(n) AS total_node_count"
         with self.driver.session() as session:
-            result = session.run(query)
-            count = result.single()["total_node_count"]
+            count = session.run(
+                "MATCH (n) RETURN count(n) AS total_node_count"
+            ).single()["total_node_count"]
             logger.info(f"Total nodes in database: {count}")
             return count
 
     def check_stock_exists(self, stock_code: str) -> bool:
-        """Check if stock data already exists in database.
-
-        Args:
-            stock_code: Stock code to check
-
-        Returns:
-            True if stock exists, False otherwise
-        """
-        query = """
-        MATCH (c:Company {stock_code: $stock_code})
-        RETURN count(c) > 0 AS exists
-        """
         with self.driver.session() as session:
-            result = session.run(query, stock_code=stock_code)
-            return result.single()["exists"]
+            return session.run(
+                "MATCH (c:Company {stock_code: $stock_code}) RETURN count(c) > 0 AS exists",
+                stock_code=stock_code,
+            ).single()["exists"]
 
     def check_stock_date_exists(self, stock_code: str, date: str) -> bool:
-        """Check if stock data for specific date already exists.
-
-        Args:
-            stock_code: Stock code to check
-            date: Date in YYYYMMDD format
-
-        Returns:
-            True if data exists for this date, False otherwise
-        """
-        query = """
-        MATCH (c:Company {stock_code: $stock_code})-[:HAS_STOCK_PRICE]->(sp:StockPrice)-[:RECORDED_ON]->(d:Date {date: $date})
-        RETURN count(sp) > 0 AS exists
-        """
         with self.driver.session() as session:
-            result = session.run(query, stock_code=stock_code, date=date)
-            return result.single()["exists"]
+            return session.run(
+                "MATCH (c:Company {stock_code: $stock_code})-[:HAS_STOCK_PRICE]->(sp:StockPrice)-[:RECORDED_ON]->(d:Date {date: $date}) RETURN count(sp) > 0 AS exists",
+                stock_code=stock_code,
+                date=date,
+            ).single()["exists"]
 
     def get_processed_stocks(self) -> set:
-        """Get set of all stock codes that have been processed.
-
-        Returns:
-            Set of stock codes
-        """
-        query = "MATCH (c:Company) RETURN c.stock_code AS stock_code"
         with self.driver.session() as session:
-            result = session.run(query)
-            return {record["stock_code"] for record in result}
+            return {
+                r["stock_code"]
+                for r in session.run(
+                    "MATCH (c:Company) RETURN c.stock_code AS stock_code"
+                )
+            }
 
     def get_processed_dates_for_stock(self, stock_code: str) -> set:
-        """Get set of dates that have been processed for a stock.
-
-        Args:
-            stock_code: Stock code to check
-
-        Returns:
-            Set of dates in YYYYMMDD format
-        """
-        query = """
-        MATCH (c:Company {stock_code: $stock_code})-[:HAS_STOCK_PRICE]->(:StockPrice)-[:RECORDED_ON]->(d:Date)
-        RETURN d.date AS date
-        """
         with self.driver.session() as session:
-            result = session.run(query, stock_code=stock_code)
-            return {record["date"] for record in result}
+            return {
+                r["date"]
+                for r in session.run(
+                    "MATCH (c:Company {stock_code: $stock_code})-[:HAS_STOCK_PRICE]->(:StockPrice)-[:RECORDED_ON]->(d:Date) RETURN d.date AS date",
+                    stock_code=stock_code,
+                )
+            }

--- a/src/stockelper_kg/graph/cypher.py
+++ b/src/stockelper_kg/graph/cypher.py
@@ -10,27 +10,16 @@ def payload_to_cypher(payload: GraphPayload) -> str:
     alias_map = {node.key: f"n{idx}" for idx, node in enumerate(payload.nodes)}
     statements = []
 
-    for idx, node in enumerate(payload.nodes):
-        alias = f"n{idx}"
+    for node in payload.nodes:
+        alias = alias_map[node.key]
         identity_keys = _get_identity_keys(node.label, node.properties)
-        identity_props = {
-            k: node.properties[k] for k in identity_keys if k in node.properties
-        }
-        if not identity_props:
-            identity_props = dict(node.properties)
-
-        merge_props = ", ".join(
-            f"{k}: {_format_value(v)}" for k, v in sorted(identity_props.items())
-        )
+        identity_props = {k: node.properties[k] for k in identity_keys if k in node.properties} or dict(node.properties)
+        merge_props = ", ".join(f"{k}: {_format_value(v)}" for k, v in sorted(identity_props.items()))
         statements.append(f"MERGE ({alias}:{node.label} {{{merge_props}}})")
 
-        remaining = {
-            k: v for k, v in node.properties.items() if k not in identity_props
-        }
+        remaining = {k: v for k, v in node.properties.items() if k not in identity_props}
         if remaining:
-            set_props = ", ".join(
-                f"{k}: {_format_value(v)}" for k, v in sorted(remaining.items())
-            )
+            set_props = ", ".join(f"{k}: {_format_value(v)}" for k, v in sorted(remaining.items()))
             statements.append(f"SET {alias} += {{{set_props}}}")
 
     for edge in payload.edges:
@@ -47,20 +36,15 @@ def payload_to_cypher(payload: GraphPayload) -> str:
 
 def _get_identity_keys(label: str, props: dict[str, Any]) -> tuple[str, ...]:
     definition = ONTOLOGY.node_map.get(label)
-    if not definition or not definition.primary_keys:
-        return ()
-    for key_tuple in definition.primary_keys:
-        if all(k in props and _has_value(props[k]) for k in key_tuple):
-            return key_tuple
+    if definition and definition.primary_keys:
+        for key_tuple in definition.primary_keys:
+            if all(_has_value(props.get(k)) for k in key_tuple):
+                return key_tuple
     return ()
 
 
 def _has_value(val: Any) -> bool:
-    if val is None:
-        return False
-    if isinstance(val, str):
-        return bool(val.strip())
-    return True
+    return bool(val.strip()) if isinstance(val, str) else val is not None
 
 
 def _format_value(value: Any) -> str:

--- a/src/stockelper_kg/graph/cypher.py
+++ b/src/stockelper_kg/graph/cypher.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+from typing import Any
+
+from .ontology import ONTOLOGY
+from .schema import GraphNodeSpec, GraphPayload
+
+
+def payload_to_cypher(payload: GraphPayload) -> str:
+    alias_map = {node.key: f"n{idx}" for idx, node in enumerate(payload.nodes)}
+    statements = []
+
+    for idx, node in enumerate(payload.nodes):
+        alias = f"n{idx}"
+        identity_keys = _get_identity_keys(node.label, node.properties)
+        identity_props = {
+            k: node.properties[k] for k in identity_keys if k in node.properties
+        }
+        if not identity_props:
+            identity_props = dict(node.properties)
+
+        merge_props = ", ".join(
+            f"{k}: {_format_value(v)}" for k, v in sorted(identity_props.items())
+        )
+        statements.append(f"MERGE ({alias}:{node.label} {{{merge_props}}})")
+
+        remaining = {
+            k: v for k, v in node.properties.items() if k not in identity_props
+        }
+        if remaining:
+            set_props = ", ".join(
+                f"{k}: {_format_value(v)}" for k, v in sorted(remaining.items())
+            )
+            statements.append(f"SET {alias} += {{{set_props}}}")
+
+    for edge in payload.edges:
+        src = alias_map.get(edge.source)
+        tgt = alias_map.get(edge.target)
+        if not src or not tgt:
+            raise ValueError(
+                f"Edge {edge.type} references unknown node: {edge.source} -> {edge.target}"
+            )
+        statements.append(f"MERGE ({src})-[:{edge.type}]->({tgt})")
+
+    return "\n".join(statements)
+
+
+def _get_identity_keys(label: str, props: dict[str, Any]) -> tuple[str, ...]:
+    definition = ONTOLOGY.node_map.get(label)
+    if not definition or not definition.primary_keys:
+        return ()
+    for key_tuple in definition.primary_keys:
+        if all(k in props and _has_value(props[k]) for k in key_tuple):
+            return key_tuple
+    return ()
+
+
+def _has_value(val: Any) -> bool:
+    if val is None:
+        return False
+    if isinstance(val, str):
+        return bool(val.strip())
+    return True
+
+
+def _format_value(value: Any) -> str:
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    if isinstance(value, (int, float)) and not isinstance(value, bool):
+        return str(value)
+    if isinstance(value, (list, tuple, set)):
+        return f"[{', '.join(_format_value(v) for v in value)}]"
+    if isinstance(value, dict):
+        inner = ", ".join(f"{k}: {_format_value(v)}" for k, v in value.items())
+        return f"{{{inner}}}"
+    escaped = str(value).replace("\\", "\\\\").replace("'", "\\'")
+    return f"'{escaped}'"
+
+
+def generate_constraints() -> str:
+    statements = []
+    for label, definition in ONTOLOGY.node_map.items():
+        if not definition.primary_keys:
+            continue
+        primary = definition.primary_keys[0]
+        if len(primary) == 1:
+            statements.append(
+                f"CREATE CONSTRAINT {label.lower()}_{primary[0]} IF NOT EXISTS "
+                f"FOR (n:{label}) REQUIRE n.{primary[0]} IS UNIQUE"
+            )
+        else:
+            for prop in primary:
+                statements.append(
+                    f"CREATE INDEX {label.lower()}_{prop}_idx IF NOT EXISTS "
+                    f"FOR (n:{label}) ON (n.{prop})"
+                )
+    return ";\n".join(statements) + ";" if statements else ""

--- a/src/stockelper_kg/graph/event.py
+++ b/src/stockelper_kg/graph/event.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+import json
+import logging
+import sys
+from pathlib import Path
+from typing import Any
+
+from dotenv import load_dotenv
+from openai import OpenAI
+
+from .ontology import ONTOLOGY, build_ontology_prompts
+
+load_dotenv()
+
+client = OpenAI()
+logger = logging.getLogger(__name__)
+
+
+def classify_event(event: str, model: str = "gpt-4o-mini") -> dict[str, Any]:
+    if not event or not event.strip():
+        raise ValueError("event text is empty")
+
+    ontology = build_ontology_prompts(detail="full")
+    event_types = ", ".join(ONTOLOGY.event_map.keys())
+    prompt = f"""
+Classify financial news/events into ontology event types and extract slots.
+
+[EVENT ONTOLOGY]
+{ontology["events"]}
+
+Task:
+1. Extract event_type and corp_name from text (REQUIRED - must be in output root).
+2. Fill required_slots: ONLY slots in ontology's "required" list for chosen event_type.
+3. Fill optional_slots: Any other relevant info NOT in ontology's required list.
+
+[INPUT TEXT]
+{event.strip()}
+
+[OUTPUT JSON SCHEMA]
+{{
+  "event_type": "{event_types}, or OTHER if none applies",
+  "corp_name": "Company name (REQUIRED - extract from text)",
+  "summary": "Key summary (1 sentence)",
+  "required_slots": {{ "date": "...", ... }},
+  "optional_slots": {{ "product_id": "...", ... }},
+  "reported_by": "YYYY-MM-DD",
+  "reported_at": "..."
+}}
+"""
+
+    resp = client.chat.completions.create(
+        model=model,
+        messages=[{"role": "user", "content": prompt}],
+        temperature=0,
+        response_format={"type": "json_object"},
+        max_tokens=600,
+    )
+
+    try:
+        data = json.loads(resp.choices[0].message.content)
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"Failed to parse LLM response: {exc}") from exc
+
+    data.setdefault("required_slots", {})
+    data.setdefault("optional_slots", {})
+
+    etype = data.get("event_type") or "OTHER"
+    if etype not in ONTOLOGY.event_map:
+        etype = "OTHER"
+    data["event_type"] = etype
+
+    corp_name = (
+        data.get("corp_name") or data["required_slots"].get("corp_name") or ""
+    ).strip()
+    if not corp_name:
+        raise ValueError("corp_name is required but not found in LLM response")
+    data["corp_name"] = corp_name
+    if date := data["required_slots"].get("date"):
+        data["date"] = date
+
+    logger.info(f"Event: {data}")
+    return data
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2:
+        print("Usage: python -m stockelper_kg.graph.event <path/to/textfile>")
+        raise SystemExit(1)
+
+    path = Path(sys.argv[1]).expanduser()
+    if not path.is_file():
+        print(f"File not found: {path}")
+        raise SystemExit(1)
+
+    text = path.read_text(encoding="utf-8")
+    result = classify_event(text)
+    print(json.dumps(result, ensure_ascii=False, indent=2))

--- a/src/stockelper_kg/graph/ontology.py
+++ b/src/stockelper_kg/graph/ontology.py
@@ -381,6 +381,98 @@ _NODE_DEFINITIONS: Tuple[NodeDefinition, ...] = (
         ),
     ),
     NodeDefinition(
+        name="PriceDate",
+        description="시세 데이터 전용 날짜 노드 (캘린더 Date와 매핑)",
+        separation_reason="시세 노드 수가 많아도 공용 Date 과밀을 피하기 위함",
+        examples=("2025-01-01",),
+        primary_keys=(("date",),),
+        properties=(
+            NodeProperty("날짜", "date", "내부", "YYYY-MM-DD 포맷"),
+            NodeProperty("연도", "year", "내부", "int(date[:4])"),
+            NodeProperty(
+                "월",
+                "month",
+                "내부",
+                'int(date.replace("-", "")[4:6])',
+            ),
+            NodeProperty(
+                "일",
+                "day",
+                "내부",
+                'int(date.replace("-", "")[6:8])',
+            ),
+        ),
+    ),
+    NodeDefinition(
+        name="FinancialDate",
+        description="재무제표 전용 날짜 노드 (캘린더 Date와 매핑)",
+        separation_reason="재무 데이터의 기준/공시일을 캘린더 Date와 분리",
+        examples=("2025-02-15",),
+        primary_keys=(("date",),),
+        properties=(
+            NodeProperty("날짜", "date", "내부", "YYYY-MM-DD 포맷"),
+            NodeProperty("연도", "year", "내부", "int(date[:4])"),
+            NodeProperty(
+                "월",
+                "month",
+                "내부",
+                'int(date.replace("-", "")[4:6])',
+            ),
+            NodeProperty(
+                "일",
+                "day",
+                "내부",
+                'int(date.replace("-", "")[6:8])',
+            ),
+        ),
+    ),
+    NodeDefinition(
+        name="IndicatorDate",
+        description="파생 지표 전용 날짜 노드 (캘린더 Date와 매핑)",
+        separation_reason="Indicator 시계열을 캘린더 Date로 묶기 전 완충층",
+        examples=("2025-01-01",),
+        primary_keys=(("date",),),
+        properties=(
+            NodeProperty("날짜", "date", "내부", "YYYY-MM-DD 포맷"),
+            NodeProperty("연도", "year", "내부", "int(date[:4])"),
+            NodeProperty(
+                "월",
+                "month",
+                "내부",
+                'int(date.replace("-", "")[4:6])',
+            ),
+            NodeProperty(
+                "일",
+                "day",
+                "내부",
+                'int(date.replace("-", "")[6:8])',
+            ),
+        ),
+    ),
+    NodeDefinition(
+        name="EventDate",
+        description="이벤트 전용 날짜 노드 (캘린더 Date와 매핑)",
+        separation_reason="뉴스/공시 이벤트의 일자를 캘린더 Date와 분리",
+        examples=("2025-01-01",),
+        primary_keys=(("date",),),
+        properties=(
+            NodeProperty("날짜", "date", "내부", "YYYY-MM-DD 포맷"),
+            NodeProperty("연도", "year", "내부", "int(date[:4])"),
+            NodeProperty(
+                "월",
+                "month",
+                "내부",
+                'int(date.replace("-", "")[4:6])',
+            ),
+            NodeProperty(
+                "일",
+                "day",
+                "내부",
+                'int(date.replace("-", "")[6:8])',
+            ),
+        ),
+    ),
+    NodeDefinition(
         name="FinancialStatements",
         description="재무제표 계정 단위 데이터",
         separation_reason="정량 값 추적",
@@ -556,6 +648,15 @@ _EDGE_DEFINITIONS: Tuple[EdgeDefinition, ...] = (
         "HAS_SECURITY", "Company → Security", "종목 코드 매핑", "삼성전자 → 005930"
     ),
     EdgeDefinition(
+        "ON_DATE", "Company → Date", "회사 단위 날짜 허브 연결", "삼성전자 → 2025-01-01"
+    ),
+    EdgeDefinition(
+        "IS_DATE",
+        "PriceDate/FinancialDate/IndicatorDate/EventDate → Date",
+        "타입별 날짜를 공용 캘린더 Date에 매핑",
+        "PriceDate → 2025-01-01",
+    ),
+    EdgeDefinition(
         "HAS_STOCK_PRICE",
         "Company → StockPrice",
         "일별 주가 연결",
@@ -568,10 +669,22 @@ _EDGE_DEFINITIONS: Tuple[EdgeDefinition, ...] = (
         "삼성전자 → FY2024 재무제표",
     ),
     EdgeDefinition(
+        "REPORTED_ON",
+        "FinancialStatements → FinancialDate",
+        "재무제표 기준/공시일 연결 (타입별 날짜 노드)",
+        "FY2024 재무제표 → 2025-02-15",
+    ),
+    EdgeDefinition(
         "HAS_INDICATOR",
         "Company → Indicator",
         "파생 재무지표 연결",
         "삼성전자 → EPS/PER",
+    ),
+    EdgeDefinition(
+        "MEASURED_ON",
+        "Indicator → IndicatorDate",
+        "파생 지표 기준일 연결 (타입별 날짜 노드)",
+        "EPS/PER → 2025-01-01",
     ),
     EdgeDefinition(
         "HAS_OFFICER", "Company → Person", "임원/CEO 연결", "삼성전자 → 이재용"
@@ -634,10 +747,16 @@ _EDGE_DEFINITIONS: Tuple[EdgeDefinition, ...] = (
         "HAS_EVENT", "Company → Event", "레거시 이벤트 연결", "삼성전자 → 2025Q1"
     ),
     EdgeDefinition(
-        "OCCURRED_ON", "Event → Date", "이벤트 발생일 연결", "증설 → 2025-09-01"
+        "OCCURRED_ON",
+        "Event → EventDate",
+        "이벤트 발생일 연결 (타입별 날짜 노드)",
+        "증설 → 2025-09-01",
     ),
     EdgeDefinition(
-        "RECORDED_ON", "StockPrice → Date", "시세 기록 날짜", "주가 → 2025-09-01"
+        "RECORDED_ON",
+        "StockPrice → PriceDate",
+        "시세 기록 날짜 (타입별 날짜 노드)",
+        "주가 → 2025-09-01",
     ),
 )
 

--- a/src/stockelper_kg/graph/ontology.py
+++ b/src/stockelper_kg/graph/ontology.py
@@ -1,0 +1,820 @@
+"""Structured node, edge, and event ontology definitions."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, Tuple, Literal
+
+
+PromptDetail = Literal["full", "lite"]
+
+
+@dataclass(frozen=True)
+class NodeProperty:
+    """Represents a property belonging to a node definition."""
+
+    name: str
+    key: str
+    api: str
+    method: str
+
+    def to_prompt_dict(self, detail: PromptDetail = "full") -> dict:
+        """Serialise to a JSON-friendly dict."""
+        data = {"name": self.name, "key": self.key}
+        if detail == "full":
+            data["api"] = self.api
+            data["method"] = self.method
+        return data
+
+
+PrimaryKey = Tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class NodeDefinition:
+    """Represents an entity type in the knowledge graph."""
+
+    name: str
+    description: str
+    separation_reason: str
+    examples: Tuple[str, ...]
+    primary_keys: Tuple[PrimaryKey, ...]
+    properties: Tuple[NodeProperty, ...] = ()
+
+    def to_prompt_dict(self, detail: PromptDetail = "full") -> dict:
+        """Serialise to JSON-friendly dict."""
+        data = {
+            "name": self.name,
+            "description": self.description,
+            "primary_keys": [
+                keys[0] if len(keys) == 1 else " + ".join(keys)
+                for keys in self.primary_keys
+            ],
+        }
+        if detail == "full":
+            data["separation_reason"] = self.separation_reason
+            if self.examples:
+                data["examples"] = list(self.examples)
+        elif self.examples:
+            data["example"] = self.examples[0]
+        if self.properties:
+            data["properties"] = [
+                prop.to_prompt_dict(detail=detail) for prop in self.properties
+            ]
+        return data
+
+
+@dataclass(frozen=True)
+class EdgeDefinition:
+    """Represents a relationship type between entities."""
+
+    name: str
+    direction: str
+    description: str
+    example: str
+    symmetric: bool = False
+
+    def to_prompt_dict(self, detail: PromptDetail = "full") -> dict:
+        """Serialise to JSON-friendly dict."""
+        data = {
+            "name": self.name,
+            "direction": self.direction,
+            "description": self.description,
+            "symmetric": self.symmetric,
+        }
+        if detail == "full" and self.example:
+            data["example"] = self.example
+        return data
+
+
+@dataclass(frozen=True)
+class EventDefinition:
+    """Represents one event type from the ontology."""
+
+    type: str
+    description: str
+    guideline: str
+    required_slots: Tuple[str, ...]
+    optional_slots: Tuple[str, ...]
+
+    def to_prompt_dict(self, detail: PromptDetail = "full") -> dict:
+        """Serialise to JSON-friendly dict."""
+        data = {
+            "type": self.type,
+            "definition": self.description,
+            "slots": {
+                "required": list(self.required_slots),
+            },
+        }
+        if detail == "full":
+            data["slots"]["optional"] = list(self.optional_slots)
+        if self.guideline:
+            data["guideline"] = self.guideline
+        return data
+
+
+_NODE_DEFINITIONS: Tuple[NodeDefinition, ...] = (
+    NodeDefinition(
+        name="Company",
+        description="모든 그래프의 중심이 되는 기업 단위 엔티티",
+        separation_reason="corp_code 기반으로 고유 식별 가능",
+        examples=("삼성전자", "BYD"),
+        primary_keys=(
+            ("stock_code",),
+            ("corp_code",),
+            ("corp_name",),
+        ),
+        properties=(
+            NodeProperty(
+                "고유번호",
+                "corp_code",
+                "OpenDART corpCode.xml",
+                'dart.corp_code("삼성전자")',
+            ),
+            NodeProperty(
+                "한글명",
+                "corp_name",
+                "OpenDART company.json",
+                'dart.company_profile(cc)["corp_name"]',
+            ),
+            NodeProperty(
+                "영문명",
+                "corp_name_eng",
+                "OpenDART company.json",
+                'dart.company_profile(cc)["corp_name_eng"]',
+            ),
+            NodeProperty(
+                "산업코드",
+                "induty_code",
+                "OpenDART company.json",
+                'dart.company_profile(cc)["induty_code"]',
+            ),
+            NodeProperty(
+                "시장구분",
+                "corp_cls",
+                "OpenDART company.json",
+                'dart.company_profile(cc)["corp_cls"]',
+            ),
+            NodeProperty(
+                "종목코드",
+                "stock_code",
+                "OpenDART company.json",
+                'dart.company_profile(cc)["stock_code"]',
+            ),
+            NodeProperty(
+                "섹터",
+                "std_idst_clsf_cd_name",
+                "KIS",
+                "kis.indicator(stock_code)",
+            ),
+            NodeProperty(
+                "자본금",
+                "capital_stock",
+                "KIS / OpenDART 재무",
+                'dart.finstate_map_accounts(dart.finstate(cc, 2024))["capital_stock"]["value"]',
+            ),
+        ),
+    ),
+    NodeDefinition(
+        name="Event",
+        description="기업의 사건(공시, 뉴스)",
+        separation_reason="시점, 영향, 참여 주체가 구분되는 행위 단위",
+        examples=("합병", "증설", "규제"),
+        primary_keys=(("event_id",),),
+        properties=(
+            NodeProperty(
+                "사건ID",
+                "event_id",
+                "내부",
+                'f"EVT_{rcept_no}"',
+            ),
+            NodeProperty(
+                "유형(L1)",
+                "pblntf_ty",
+                "OpenDART list.json",
+                'row.get("pblntf_ty", "B")',
+            ),
+            NodeProperty(
+                "유형(L2)",
+                "pblntf_detail_ty",
+                "OpenDART list.json",
+                'row.get("pblntf_detail_ty", row.get("report_nm"))',
+            ),
+            NodeProperty(
+                "일자",
+                "reported_at",
+                "OpenDART list.json",
+                'row["rcept_dt"]',
+            ),
+        ),
+    ),
+    NodeDefinition(
+        name="Document",
+        description="원천 데이터(공시, 뉴스 기사)",
+        separation_reason="이벤트와 원천 자료를 분리하여 다대다 연결",
+        examples=("DART 2025-09A", "연합뉴스 2025-09-01"),
+        primary_keys=(
+            ("rcept_no",),
+            ("document_id",),
+            ("url",),
+            ("title",),
+        ),
+        properties=(
+            NodeProperty(
+                "공시번호",
+                "rcept_no",
+                "OpenDART list.json",
+                'dart.list_filings(cc,"2025-01-01","2025-12-31","B").iloc[0]["rcept_no"]',
+            ),
+            NodeProperty(
+                "제목",
+                "report_nm",
+                "OpenDART list.json",
+                'df.iloc[0]["report_nm"]',
+            ),
+            NodeProperty(
+                "게시일",
+                "rcept_dt",
+                "OpenDART list.json",
+                'df.iloc[0]["rcept_dt"]',
+            ),
+            NodeProperty(
+                "URL",
+                "url",
+                "DART viewer / 뉴스 링크",
+                "dart.document_url(rcept_no)",
+            ),
+            NodeProperty(
+                "본문",
+                "body",
+                "OpenDART document.xml / 기사 전문",
+                "dart.document_text(rcept_no)",
+            ),
+        ),
+    ),
+    NodeDefinition(
+        name="Person",
+        description="임원·대주주 등 실질 주체",
+        separation_reason="시계열 관계(임기, 지분)는 엣지에서 표현",
+        examples=("이재용", "정용진"),
+        primary_keys=(("name_ko", "corp_code"),),
+        properties=(
+            NodeProperty(
+                "이름",
+                "name_ko",
+                "OpenDART majorstock.json",
+                'dart.major_shareholders(cc).iloc[0].get("rprt_nm")',
+            ),
+        ),
+    ),
+    NodeDefinition(
+        name="Product",
+        description="사업보고서의 주요 제품 및 서비스",
+        separation_reason="제품군 단위 분석",
+        examples=("DRAM", "Galaxy S24"),
+        primary_keys=(
+            ("product_id",),
+            ("name",),
+        ),
+        properties=(
+            NodeProperty(
+                "제품ID",
+                "product_id",
+                "사업보고서 본문",
+                'dart.extract_products(text, rcept_no)[0]["product_id"]',
+            ),
+            NodeProperty(
+                "제품명",
+                "name",
+                "사업보고서 본문",
+                'dart.extract_products(text, rcept_no)[0]["name"]',
+            ),
+            NodeProperty(
+                "제품군",
+                "category",
+                "사업보고서 본문",
+                'dart.extract_products(text, rcept_no)[0]["category"]',
+            ),
+        ),
+    ),
+    NodeDefinition(
+        name="Facility",
+        description="생산라인·공장",
+        separation_reason="CAPEX/중단 이벤트 반복 축",
+        examples=("평택 P3",),
+        primary_keys=(("facility_id",),),
+        properties=(
+            NodeProperty(
+                "설비ID",
+                "facility_id",
+                "사업보고서/주요사항 본문",
+                'dart.extract_facilities(text, rcept_no)[0]["facility_id"]',
+            ),
+            NodeProperty(
+                "지역",
+                "region",
+                "본문",
+                'dart.extract_facilities(text, rcept_no)[0].get("region")',
+            ),
+            NodeProperty(
+                "CAPA",
+                "capacity",
+                "본문",
+                'dart.extract_facilities(text, rcept_no)[0].get("capacity")',
+            ),
+        ),
+    ),
+    NodeDefinition(
+        name="Observation",
+        description="시계열 수치 데이터 (가격, 매출, 금리 등)",
+        separation_reason="시점별 기록을 독립 노드로 관리",
+        examples=("종가", "매출액"),
+        primary_keys=(("metric", "observed_at", "corp_code"),),
+        properties=(
+            NodeProperty(
+                "지표명",
+                "metric",
+                "다양한 원천",
+                "도메인별 수집 로직 참조",
+            ),
+            NodeProperty(
+                "값",
+                "value",
+                "다양한 원천",
+                "수집된 시계열 값",
+            ),
+            NodeProperty(
+                "관측일",
+                "observed_at",
+                "다양한 원천",
+                "관측 일자",
+            ),
+            NodeProperty(
+                "단위",
+                "unit",
+                "다양한 원천",
+                "지표 단위",
+            ),
+        ),
+    ),
+    NodeDefinition(
+        name="Date",
+        description="그래프 내 모든 시계열 노드와 사건을 정규화하는 날짜 노드",
+        separation_reason="여러 이벤트/관측치가 동일 날짜를 공유하므로 중복을 방지",
+        examples=("2025-01-01",),
+        primary_keys=(("date",),),
+        properties=(
+            NodeProperty("날짜", "date", "내부", "YYYY-MM-DD 포맷"),
+            NodeProperty("연도", "year", "내부", "int(date[:4])"),
+            NodeProperty(
+                "월",
+                "month",
+                "내부",
+                'int(date.replace("-", "")[4:6])',
+            ),
+            NodeProperty(
+                "일",
+                "day",
+                "내부",
+                'int(date.replace("-", "")[6:8])',
+            ),
+        ),
+    ),
+    NodeDefinition(
+        name="FinancialStatements",
+        description="재무제표 계정 단위 데이터",
+        separation_reason="정량 값 추적",
+        examples=("매출액", "영업이익"),
+        # NOTE:
+        # - GraphBuilder 및 Neo4j constraint 가 (stock_code, fiscal_year, fiscal_period)
+        #   조합을 기본 키로 사용하므로 여기도 동일하게 맞춘다.
+        primary_keys=(("stock_code", "fiscal_year", "fiscal_period"),),
+        properties=(
+            NodeProperty(
+                "매출액",
+                "revenue",
+                "OpenDART finstate()",
+                'dart.finstate_map_accounts(dart.finstate(cc, 2024))["revenue"]["value"]',
+            ),
+            NodeProperty(
+                "영업이익",
+                "operating_income",
+                "OpenDART finstate()",
+                '...["operating_income"]["value"]',
+            ),
+            NodeProperty(
+                "당기순이익",
+                "net_income",
+                "OpenDART finstate()",
+                '...["net_income"]["value"]',
+            ),
+            NodeProperty(
+                "자산총계",
+                "total_assets",
+                "OpenDART finstate()",
+                '...["total_assets"]["value"]',
+            ),
+            NodeProperty(
+                "부채총계",
+                "total_liabilities",
+                "OpenDART finstate()",
+                '...["total_liabilities"]["value"]',
+            ),
+            NodeProperty(
+                "자본총계",
+                "total_equity",
+                "OpenDART finstate()",
+                '...["total_equity"]["value"]',
+            ),
+            NodeProperty(
+                "자본금",
+                "capital_stock",
+                "OpenDART finstate()",
+                '...["capital_stock"]["value"]',
+            ),
+        ),
+    ),
+    NodeDefinition(
+        name="Indicator",
+        description="파생 재무지표",
+        separation_reason="KIS 등 외부 지표 연동",
+        examples=("EPS", "PBR"),
+        primary_keys=(("stock_code", "as_of"),),
+        properties=(
+            NodeProperty(
+                "EPS",
+                "eps",
+                "KIS inquire-price",
+                'kis.indicator(stock_code)["eps"]',
+            ),
+            NodeProperty(
+                "PER",
+                "per",
+                "KIS inquire-price",
+                'kis.indicator(stock_code)["per"]',
+            ),
+            NodeProperty(
+                "PBR",
+                "pbr",
+                "KIS inquire-price",
+                'kis.indicator(stock_code)["pbr"]',
+            ),
+            NodeProperty(
+                "BPS",
+                "bps",
+                "KIS inquire-price",
+                'kis.indicator(stock_code)["bps"]',
+            ),
+        ),
+    ),
+    NodeDefinition(
+        name="StockPrice",
+        description="분/일 단위 시세 데이터",
+        separation_reason="시장 시세를 Observation과 별도 관리",
+        examples=("시가", "종가"),
+        primary_keys=(("stock_code", "traded_at"),),
+        properties=(
+            NodeProperty(
+                "시가",
+                "stck_oprc",
+                "KIS inquire-daily-price",
+                'kis.daily_price(stock_code,"20250101","20250131")[0]["stck_oprc"]',
+            ),
+            NodeProperty(
+                "종가",
+                "stck_prpr",
+                "KIS inquire-daily-price",
+                '...["stck_prpr"]',
+            ),
+            NodeProperty(
+                "고가",
+                "stck_hgpr",
+                "KIS inquire-daily-price",
+                '...["stck_hgpr"]',
+            ),
+            NodeProperty(
+                "저가",
+                "stck_lwpr",
+                "KIS inquire-daily-price",
+                '...["stck_lwpr"]',
+            ),
+            NodeProperty(
+                "상한가",
+                "stck_mxpr",
+                "KIS inquire-daily-price",
+                '...["stck_mxpr"]',
+            ),
+            NodeProperty(
+                "하한가",
+                "stck_llam",
+                "KIS inquire-daily-price",
+                '...["stck_llam"]',
+            ),
+            NodeProperty(
+                "전일종가",
+                "stck_sdpr",
+                "KIS inquire-daily-price",
+                '...["stck_sdpr"]',
+            ),
+        ),
+    ),
+    NodeDefinition(
+        name="Security",
+        description="상장 유가증권",
+        separation_reason="회사와 종목코드 연결",
+        examples=("005930", "000660"),
+        primary_keys=(
+            ("stock_code",),
+            ("isin",),
+        ),
+        properties=(
+            NodeProperty("종목코드", "stock_code", "KRX", "krx.lookup(stock_name)"),
+            NodeProperty("ISIN", "isin", "KRX", "krx.lookup_isin(stock_code)"),
+            NodeProperty("티커", "ticker", "해외거래소", "custom mapping"),
+            NodeProperty("시장", "market", "KRX", "krx.market(stock_code)"),
+            NodeProperty("통화", "currency", "KRX/KIS", "krx.currency(stock_code)"),
+        ),
+    ),
+    NodeDefinition(
+        name="Metric",
+        description="Observation 단위 지표 메타데이터",
+        separation_reason="Observation 값의 단위를 명시",
+        examples=("PRICE.CLOSE", "SALES"),
+        primary_keys=(("metric_id",),),
+        properties=(
+            NodeProperty("지표ID", "metric_id", "내부", "도메인 정의"),
+            NodeProperty("지표명", "name", "내부", "도메인 정의"),
+            NodeProperty("단위", "unit", "내부", "도메인 정의"),
+            NodeProperty("설명", "description", "내부", "도메인 정의"),
+        ),
+    ),
+)
+
+
+_EDGE_DEFINITIONS: Tuple[EdgeDefinition, ...] = (
+    EdgeDefinition(
+        "HAS_SECURITY", "Company → Security", "종목 코드 매핑", "삼성전자 → 005930"
+    ),
+    EdgeDefinition(
+        "HAS_STOCK_PRICE",
+        "Company → StockPrice",
+        "일별 주가 연결",
+        "삼성전자 → 2025-01-01",
+    ),
+    EdgeDefinition(
+        "HAS_FINANCIAL_STATEMENTS",
+        "Company → FinancialStatements",
+        "재무제표 계정 연결",
+        "삼성전자 → FY2024 재무제표",
+    ),
+    EdgeDefinition(
+        "HAS_INDICATOR",
+        "Company → Indicator",
+        "파생 재무지표 연결",
+        "삼성전자 → EPS/PER",
+    ),
+    EdgeDefinition(
+        "HAS_OFFICER", "Company → Person", "임원/CEO 연결", "삼성전자 → 이재용"
+    ),
+    EdgeDefinition(
+        "HAS_SUBSIDIARY", "Company → Company", "그룹 관계", "SK하이닉스 → 솔리다임"
+    ),
+    EdgeDefinition(
+        "BENEFICIAL_OWNER",
+        "Person → Company",
+        "지분율 관계",
+        "이재용 → 삼성전자 (18.1%)",
+    ),
+    EdgeDefinition(
+        "INVOLVED_IN", "Company → Event", "기업이 사건에 참여", "삼성전자 → 평택 증설"
+    ),
+    EdgeDefinition(
+        "REPORTED_BY", "Event → Document", "출처 연결", "증설 결정 → DART 2025-09"
+    ),
+    EdgeDefinition(
+        "AFFECTS", "Event → Observation", "사건의 영향", "증설 → 주가(+2.1%)"
+    ),
+    EdgeDefinition(
+        "CAUSES", "Event → Event", "사건의 인과관계", "ESS 수요 → 엘앤에프 주가 급등"
+    ),
+    EdgeDefinition(
+        "HAS_PRODUCT", "Company → Product", "제품군 연결", "삼성전자 → DRAM"
+    ),
+    EdgeDefinition(
+        "HAS_FACILITY", "Company → Facility", "생산라인 연결", "삼성전자 → 평택 P3"
+    ),
+    EdgeDefinition(
+        "OF_METRIC", "Observation → Metric", "지표 단위 연결", "70,000원 → PRICE.CLOSE"
+    ),
+    EdgeDefinition(
+        "SIMILAR_TO",
+        "Company/Product ↔ Company/Product",
+        "산업/제품 유사성",
+        "BYD ↔ SERES",
+        symmetric=True,
+    ),
+    EdgeDefinition(
+        "SIMILAR_EVENT",
+        "Event ↔ Event",
+        "내용·시점 유사",
+        "증설 ↔ 증설",
+        symmetric=True,
+    ),
+    EdgeDefinition(
+        "SUPPLIES_TO", "Company → Company", "제품/서비스 공급 관계", "삼성전자 → Apple"
+    ),
+    EdgeDefinition(
+        "IS_COMPETITOR",
+        "Company ↔ Company",
+        "경쟁사 관계",
+        "삼성전자 ↔ Apple",
+        symmetric=True,
+    ),
+    EdgeDefinition(
+        "HAS_EVENT", "Company → Event", "레거시 이벤트 연결", "삼성전자 → 2025Q1"
+    ),
+    EdgeDefinition(
+        "OCCURRED_ON", "Event → Date", "이벤트 발생일 연결", "증설 → 2025-09-01"
+    ),
+    EdgeDefinition(
+        "RECORDED_ON", "StockPrice → Date", "시세 기록 날짜", "주가 → 2025-09-01"
+    ),
+)
+
+
+_EVENT_DEFINITIONS: Tuple[EventDefinition, ...] = (
+    EventDefinition(
+        "SUPPLY_CAPACITY_CHANGE",
+        "공장 건설/증설/감산/생산능력 변경/설비투자",
+        "단순 해외 법인 설립은 제외, 설비 투자 동반 시 우선 분류",
+        ("date",),
+        (
+            "facility_id",
+            "capacity_delta",
+            "duration",
+            "total_capacity",
+            "investment_amount",
+        ),
+    ),
+    EventDefinition(
+        "SUPPLY_HALT",
+        "라인/사업장 가동중단",
+        "재해/사고 원인이라도 생산 중단이 발생하면 본 타입 우선",
+        ("date",),
+        ("facility_id", "duration", "reason", "impact"),
+    ),
+    EventDefinition(
+        "DEMAND_SALES_CONTRACT",
+        "단일판매/공급계약 체결 또는 해지",
+        "수주/발주/계약종료 포함",
+        ("counterparty", "contract_value", "date"),
+        ("duration", "product_id"),
+    ),
+    EventDefinition(
+        "REVENUE_EARNINGS",
+        "분기/연간 실적 발표 (잠정실적 포함)",
+        "",
+        ("period", "metric", "value", "date"),
+        ("consensus_comparison", "previous_comparison"),
+    ),
+    EventDefinition(
+        "EFFICIENCY_AUTOMATION",
+        "스마트팩토리/자동화/DX/공정개선 투자",
+        "",
+        ("date",),
+        ("investment_amount", "process", "facility_id", "expected_effect"),
+    ),
+    EventDefinition(
+        "STRATEGY_MNA",
+        "M&A/인수합병/지분투자",
+        "경영권 확보 목적 시 OWNERSHIP_CHANGE보다 우선",
+        ("counterparty", "deal_value", "date"),
+        ("region", "mna_type", "stake_percentage"),
+    ),
+    EventDefinition(
+        "STRATEGY_SPINOFF",
+        "인적/물적 분할·분할합병",
+        "",
+        ("counterparty", "date"),
+        ("deal_value", "region", "spinoff_type"),
+    ),
+    EventDefinition(
+        "STRATEGY_OVERSEAS",
+        "해외 투자/법인 설립/해외 진출",
+        "공장 건설 등 생산능력 변경 시 SUPPLY_CAPACITY_CHANGE로 분류",
+        ("region", "date"),
+        ("investment_amount", "facility_id", "purpose"),
+    ),
+    EventDefinition(
+        "STRATEGY_PARTNERSHIP",
+        "전략적 제휴/MOU/합작법인(JV)/공동연구",
+        "",
+        ("counterparty", "purpose", "date"),
+        ("investment_amount", "region", "capacity_plan"),
+    ),
+    EventDefinition(
+        "TECH_NEW_PRODUCT",
+        "신제품/신기술/신규 서비스 출시",
+        "",
+        ("product_id", "date"),
+        ("launch_date", "specs", "target_market"),
+    ),
+    EventDefinition(
+        "WORKFORCE_EVENT",
+        "인력 감축/채용/파업/노사합의",
+        "",
+        ("action_type", "num_employees", "date"),
+        ("duration", "participants", "reason"),
+    ),
+    EventDefinition(
+        "LEGAL_LITIGATION",
+        "소송/특허분쟁/규제기관 제재/벌금",
+        "",
+        ("counterparty", "date"),
+        ("claim_value", "court", "litigation_type"),
+    ),
+    EventDefinition(
+        "CRISIS_EVENT",
+        "화재/폭발/횡령/배임/사이버공격",
+        "생산 중단이 있으면 SUPPLY_HALT 우선",
+        ("incident_type", "location", "date"),
+        ("impact", "cause", "damage_estimate"),
+    ),
+    EventDefinition(
+        "PRODUCT_RECALL",
+        "리콜/판매중단/품질결함",
+        "",
+        ("issue", "date"),
+        ("product_id", "scope", "cost_impact"),
+    ),
+    EventDefinition(
+        "POLICY_IMPACT",
+        "정부 정책/규제 변화/세제 혜택",
+        "",
+        ("policy_name", "impact_type", "date"),
+        ("region", "value"),
+    ),
+    EventDefinition(
+        "VIRAL_EVENT",
+        "테마주/밈/유명인 발언",
+        "",
+        ("trigger", "sector", "date"),
+        ("score", "duration"),
+    ),
+    EventDefinition(
+        "OWNERSHIP_CHANGE",
+        "최대주주 변경/지분 매각/블록딜",
+        "경영권 인수 목적 M&A는 STRATEGY_MNA",
+        ("actor", "stake_change", "date"),
+        ("purpose", "value"),
+    ),
+    EventDefinition(
+        "REGULATORY_APPROVAL",
+        "FDA 승인/품목허가/임상 결과/특허 등록 등 규제 승인",
+        "",
+        ("regulator", "approval_type", "product_id", "date"),
+        ("region", "details"),
+    ),
+    EventDefinition(
+        "OTHER",
+        "위 분류에 해당하지 않는 기타 뉴스",
+        "",
+        ("description", "date"),
+        (),
+    ),
+)
+
+
+@dataclass(frozen=True)
+class Ontology:
+    """Container for graph schema definitions."""
+
+    nodes: Tuple[NodeDefinition, ...] = _NODE_DEFINITIONS
+    relationships: Tuple[EdgeDefinition, ...] = _EDGE_DEFINITIONS
+    events: Tuple[EventDefinition, ...] = _EVENT_DEFINITIONS
+
+    @property
+    def node_map(self) -> Dict[str, NodeDefinition]:
+        return {node.name: node for node in self.nodes}
+
+    @property
+    def relationship_map(self) -> Dict[str, EdgeDefinition]:
+        return {edge.name: edge for edge in self.relationships}
+
+    @property
+    def event_map(self) -> Dict[str, EventDefinition]:
+        return {event.type: event for event in self.events}
+
+
+ONTOLOGY = Ontology()
+
+
+def build_ontology_prompts(detail: PromptDetail = "full") -> dict:
+    """Build prompt dictionaries from the ontology for LLM consumption."""
+    return {
+        "events": [event.to_prompt_dict(detail=detail) for event in ONTOLOGY.events],
+        "nodes": [node.to_prompt_dict(detail=detail) for node in ONTOLOGY.nodes],
+        "relationships": [
+            rel.to_prompt_dict(detail=detail) for rel in ONTOLOGY.relationships
+        ],
+    }

--- a/src/stockelper_kg/graph/payload.py
+++ b/src/stockelper_kg/graph/payload.py
@@ -1,0 +1,207 @@
+from __future__ import annotations
+
+import hashlib
+import uuid
+from typing import Any
+
+from ..utils.dates import build_date_properties, normalize_date
+from .ontology import ONTOLOGY
+from .schema import GraphBuildContext, GraphPayload, clean_props
+
+_EVENT_DEFINITIONS = ONTOLOGY.event_map
+
+
+def _has_value(val: Any) -> bool:
+    if val is None:
+        return False
+    if isinstance(val, str):
+        return bool(val.strip())
+    if isinstance(val, (list, tuple, set, dict)):
+        return bool(val)
+    return True
+
+
+def build_graph_payload(
+    event_data: dict[str, Any],
+    metadata: dict[str, Any] | None = None,
+) -> GraphPayload:
+    event_type = event_data.get("event_type")
+    if not event_type:
+        raise ValueError("event_type is required")
+    definition = _EVENT_DEFINITIONS.get(event_type)
+    if not definition:
+        raise ValueError(f"Unknown event_type: {event_type}")
+
+    slots = {}
+    for key in ("required_slots", "optional_slots"):
+        if isinstance(event_data.get(key), dict):
+            slots.update(event_data[key])
+
+    missing = [s for s in definition.required_slots if not _has_value(slots.get(s))]
+    if missing:
+        raise ValueError(f"Missing required slots: {', '.join(missing)}")
+
+    corp_name = (event_data.get("corp_name") or slots.get("corp_name") or "").strip()
+    if not corp_name:
+        raise ValueError("corp_name is required")
+    slots["corp_name"] = corp_name
+
+    date = slots.get("date") or event_data.get("date")
+    if date:
+        from ..utils.dates import normalize_date
+
+        resolved_date = normalize_date(date)
+        if resolved_date:
+            slots["date"] = resolved_date
+
+    doc_info = _extract_document_info(metadata, event_data)
+    slots["event_id"] = _generate_event_id(
+        corp_name,
+        event_type,
+        slots.get("date"),
+        event_data.get("summary", ""),
+        doc_info,
+    )
+
+    return _build_event_graph(
+        corp_name, event_type, slots, event_data.get("summary", ""), doc_info
+    )
+
+
+def build_stock_snapshot_payload(
+    company: dict[str, Any],
+    date: str,
+    stock_price: dict[str, Any],
+    financials: dict[str, Any] | None = None,
+    indicators: dict[str, Any] | None = None,
+) -> GraphPayload:
+    context = GraphBuildContext()
+    company_node = context.add_node("Company", company)
+
+    price_props = _normalize_stock_price({"traded_at": date, **stock_price})
+    stock_node = context.add_node("StockPrice", price_props)
+    context.add_edge("HAS_STOCK_PRICE", company_node.key, stock_node.key)
+
+    date_props = build_date_properties(date)
+    if date_props:
+        date_node = context.add_node("Date", date_props)
+        context.add_edge("RECORDED_ON", stock_node.key, date_node.key)
+
+    if financials:
+        fs_node = context.add_node("FinancialStatements", financials)
+        context.add_edge("HAS_FINANCIAL_STATEMENTS", company_node.key, fs_node.key)
+
+    if indicators:
+        indicator_node = context.add_node("Indicator", indicators)
+        context.add_edge("HAS_INDICATOR", company_node.key, indicator_node.key)
+
+    return context.to_payload()
+
+
+def build_competitor_payload(
+    source_company: dict[str, Any],
+    target_company: dict[str, Any],
+) -> GraphPayload:
+    context = GraphBuildContext()
+    source_node = context.add_node("Company", source_company)
+    target_node = context.add_node("Company", target_company)
+    context.add_edge("IS_COMPETITOR", source_node.key, target_node.key)
+    context.add_edge("IS_COMPETITOR", target_node.key, source_node.key)
+    return context.to_payload()
+
+
+def _extract_document_info(
+    metadata: dict[str, Any] | None,
+    event_data: dict[str, Any],
+) -> dict[str, Any] | None:
+    sources: list[dict[str, Any]] = []
+    if metadata:
+        sources.append(metadata)
+        if isinstance(metadata.get("document"), dict):
+            sources.append(metadata["document"])
+    for key in ("document", "metadata"):
+        if isinstance(event_data.get(key), dict):
+            sources.append(event_data[key])
+
+    merged: dict[str, Any] = {}
+    for source in sources:
+        for key, value in source.items():
+            if value not in (None, "", []):
+                merged[key] = value
+
+    if not merged:
+        return None
+
+    cleaned = clean_props(merged)
+    if not cleaned:
+        return None
+
+    if "document_id" not in cleaned:
+        for key in ("rcept_no", "url", "title"):
+            if cleaned.get(key):
+                cleaned["document_id"] = cleaned[key]
+                break
+
+    return cleaned
+
+
+def _generate_event_id(
+    corp_name: str | None,
+    event_type: str | None,
+    date: str | None,
+    summary: str | None,
+    doc_info: dict[str, Any] | None,
+) -> str:
+    if doc_info and doc_info.get("document_id"):
+        content = f"{doc_info['document_id']}::{event_type or ''}"
+    else:
+        parts = [p for p in (corp_name, event_type, date, summary) if p]
+        if not parts:
+            return f"EVT_{uuid.uuid4().hex[:12].upper()}"
+        content = "::".join(parts)
+    digest = hashlib.sha1(content.encode()).hexdigest()
+    return f"EVT_{digest[:12].upper()}"
+
+
+def _build_event_graph(
+    corp_name: str,
+    event_type: str,
+    slots: dict[str, Any],
+    summary: str,
+    doc_info: dict[str, Any] | None,
+) -> GraphPayload:
+    context = GraphBuildContext()
+
+    company_node = context.add_node(
+        "Company",
+        {
+            "corp_name": corp_name,
+            "stock_nm": corp_name,
+            "corp_code": slots.get("corp_code"),
+            "stock_code": slots.get("stock_code"),
+        },
+    )
+
+    event_props = {k: v for k, v in slots.items() if k != "date"}
+    event_props["type"] = event_type
+    event_props["summary"] = summary.strip() if summary else ""
+    event_node = context.add_node("Event", event_props)
+    context.add_edge("INVOLVED_IN", company_node.key, event_node.key)
+
+    if date_str := slots.get("date"):
+        date_props = build_date_properties(date_str)
+        if date_props:
+            date_node = context.add_node("Date", date_props)
+            context.add_edge("OCCURRED_ON", event_node.key, date_node.key)
+
+    if doc_info:
+        doc_node = context.add_node("Document", doc_info)
+        context.add_edge("REPORTED_BY", event_node.key, doc_node.key)
+
+    return context.to_payload()
+
+
+def _normalize_stock_price(props: dict[str, Any]) -> dict[str, Any]:
+    props.setdefault("stck_prpr", props.get("stck_clpr"))
+    props.setdefault("stck_clpr", props.get("stck_prpr"))
+    return props

--- a/src/stockelper_kg/graph/payload.py
+++ b/src/stockelper_kg/graph/payload.py
@@ -6,19 +6,17 @@ from typing import Any
 
 from ..utils.dates import build_date_properties, normalize_date
 from .ontology import ONTOLOGY
-from .schema import GraphBuildContext, GraphPayload, clean_props
+from .schema import GraphBuildContext, GraphNodeSpec, GraphPayload, clean_props
 
 _EVENT_DEFINITIONS = ONTOLOGY.event_map
 
 
 def _has_value(val: Any) -> bool:
-    if val is None:
-        return False
     if isinstance(val, str):
         return bool(val.strip())
     if isinstance(val, (list, tuple, set, dict)):
         return bool(val)
-    return True
+    return val is not None
 
 
 def build_graph_payload(
@@ -32,10 +30,11 @@ def build_graph_payload(
     if not definition:
         raise ValueError(f"Unknown event_type: {event_type}")
 
-    slots = {}
+    slots: dict[str, Any] = {}
     for key in ("required_slots", "optional_slots"):
-        if isinstance(event_data.get(key), dict):
-            slots.update(event_data[key])
+        data = event_data.get(key)
+        if isinstance(data, dict):
+            slots.update(data)
 
     missing = [s for s in definition.required_slots if not _has_value(slots.get(s))]
     if missing:
@@ -46,12 +45,8 @@ def build_graph_payload(
         raise ValueError("corp_name is required")
     slots["corp_name"] = corp_name
 
-    date = slots.get("date") or event_data.get("date")
-    if date:
-        from ..utils.dates import normalize_date
-
-        resolved_date = normalize_date(date)
-        if resolved_date:
+    if date := slots.get("date") or event_data.get("date"):
+        if resolved_date := normalize_date(date):
             slots["date"] = resolved_date
 
     doc_info = _extract_document_info(metadata, event_data)
@@ -82,18 +77,32 @@ def build_stock_snapshot_payload(
     stock_node = context.add_node("StockPrice", price_props)
     context.add_edge("HAS_STOCK_PRICE", company_node.key, stock_node.key)
 
-    date_props = build_date_properties(date)
-    if date_props:
-        date_node = context.add_node("Date", date_props)
-        context.add_edge("RECORDED_ON", stock_node.key, date_node.key)
+    if price_date := _attach_typed_date_node(
+        context, "PriceDate", date, company_node=company_node
+    ):
+        context.add_edge("RECORDED_ON", stock_node.key, price_date.key)
 
     if financials:
         fs_node = context.add_node("FinancialStatements", financials)
         context.add_edge("HAS_FINANCIAL_STATEMENTS", company_node.key, fs_node.key)
+        if fs_date := _attach_typed_date_node(
+            context,
+            "FinancialDate",
+            financials.get("reported_date") or financials.get("date") or date,
+            company_node=company_node,
+        ):
+            context.add_edge("REPORTED_ON", fs_node.key, fs_date.key)
 
     if indicators:
         indicator_node = context.add_node("Indicator", indicators)
         context.add_edge("HAS_INDICATOR", company_node.key, indicator_node.key)
+        if ind_date := _attach_typed_date_node(
+            context,
+            "IndicatorDate",
+            indicators.get("as_of") or indicators.get("date") or date,
+            company_node=company_node,
+        ):
+            context.add_edge("MEASURED_ON", indicator_node.key, ind_date.key)
 
     return context.to_payload()
 
@@ -114,21 +123,22 @@ def _extract_document_info(
     metadata: dict[str, Any] | None,
     event_data: dict[str, Any],
 ) -> dict[str, Any] | None:
-    sources: list[dict[str, Any]] = []
-    if metadata:
-        sources.append(metadata)
-        if isinstance(metadata.get("document"), dict):
-            sources.append(metadata["document"])
-    for key in ("document", "metadata"):
-        if isinstance(event_data.get(key), dict):
-            sources.append(event_data[key])
-
-    merged: dict[str, Any] = {}
-    for source in sources:
-        for key, value in source.items():
-            if value not in (None, "", []):
-                merged[key] = value
-
+    candidates = [
+        src
+        for src in (
+            metadata,
+            metadata.get("document") if metadata else None,
+            event_data.get("document"),
+            event_data.get("metadata"),
+        )
+        if isinstance(src, dict)
+    ]
+    merged = {
+        key: value
+        for source in candidates
+        for key, value in source.items()
+        if value not in (None, "", [])
+    }
     if not merged:
         return None
 
@@ -141,7 +151,6 @@ def _extract_document_info(
             if cleaned.get(key):
                 cleaned["document_id"] = cleaned[key]
                 break
-
     return cleaned
 
 
@@ -156,9 +165,7 @@ def _generate_event_id(
         content = f"{doc_info['document_id']}::{event_type or ''}"
     else:
         parts = [p for p in (corp_name, event_type, date, summary) if p]
-        if not parts:
-            return f"EVT_{uuid.uuid4().hex[:12].upper()}"
-        content = "::".join(parts)
+        content = "::".join(parts) if parts else f"EVT_{uuid.uuid4().hex[:12].upper()}"
     digest = hashlib.sha1(content.encode()).hexdigest()
     return f"EVT_{digest[:12].upper()}"
 
@@ -172,27 +179,23 @@ def _build_event_graph(
 ) -> GraphPayload:
     context = GraphBuildContext()
 
-    company_node = context.add_node(
-        "Company",
-        {
-            "corp_name": corp_name,
-            "stock_nm": corp_name,
-            "corp_code": slots.get("corp_code"),
-            "stock_code": slots.get("stock_code"),
-        },
-    )
+    company_node = context.add_node("Company", {
+        "corp_name": corp_name,
+        "stock_nm": corp_name,
+        "corp_code": slots.get("corp_code"),
+        "stock_code": slots.get("stock_code"),
+    })
 
-    event_props = {k: v for k, v in slots.items() if k != "date"}
-    event_props["type"] = event_type
+    event_props = {**{k: v for k, v in slots.items() if k != "date"}, "type": event_type}
     event_props["summary"] = summary.strip() if summary else ""
     event_node = context.add_node("Event", event_props)
     context.add_edge("INVOLVED_IN", company_node.key, event_node.key)
 
     if date_str := slots.get("date"):
-        date_props = build_date_properties(date_str)
-        if date_props:
-            date_node = context.add_node("Date", date_props)
-            context.add_edge("OCCURRED_ON", event_node.key, date_node.key)
+        if event_date := _attach_typed_date_node(
+            context, "EventDate", date_str, company_node=company_node
+        ):
+            context.add_edge("OCCURRED_ON", event_node.key, event_date.key)
 
     if doc_info:
         doc_node = context.add_node("Document", doc_info)
@@ -205,3 +208,22 @@ def _normalize_stock_price(props: dict[str, Any]) -> dict[str, Any]:
     props.setdefault("stck_prpr", props.get("stck_clpr"))
     props.setdefault("stck_clpr", props.get("stck_prpr"))
     return props
+
+
+def _attach_typed_date_node(
+    context: GraphBuildContext,
+    label: str,
+    date_value: Any,
+    company_node: GraphNodeSpec | None = None,
+) -> GraphNodeSpec | None:
+    date_props = build_date_properties(date_value)
+    if not date_props:
+        return None
+
+    hub_date = context.add_node("Date", date_props)
+    if company_node:
+        context.add_edge("ON_DATE", company_node.key, hub_date.key)
+
+    typed_date = context.add_node(label, date_props)
+    context.add_edge("IS_DATE", typed_date.key, hub_date.key)
+    return typed_date

--- a/src/stockelper_kg/graph/schema.py
+++ b/src/stockelper_kg/graph/schema.py
@@ -1,0 +1,120 @@
+"""Graph data structures and construction primitives.
+
+This module defines the low-level building blocks for the Knowledge Graph.
+Identity/uniqueness is handled by Neo4j constraints, not client-side logic.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import asdict, dataclass, field
+from typing import Any, Dict, Iterable, Tuple
+
+
+@dataclass(frozen=True)
+class GraphNodeSpec:
+    """Node specification for graph operations."""
+
+    label: str
+    key: str
+    properties: Dict[str, Any]
+    identity_keys: Tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class GraphEdgeSpec:
+    """Edge specification for graph operations."""
+
+    type: str
+    source: str
+    target: str
+
+
+@dataclass(frozen=True)
+class GraphPayload:
+    """Immutable collection of nodes and edges."""
+
+    nodes: Tuple[GraphNodeSpec, ...]
+    edges: Tuple[GraphEdgeSpec, ...]
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "nodes": [asdict(n) for n in self.nodes],
+            "edges": [asdict(e) for e in self.edges],
+        }
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> GraphPayload:
+        nodes = tuple(GraphNodeSpec(**n) for n in data.get("nodes", []))
+        edges = tuple(GraphEdgeSpec(**e) for e in data.get("edges", []))
+        if not nodes:
+            raise ValueError("GraphPayload requires at least one node")
+        return cls(nodes=nodes, edges=edges)
+
+
+@dataclass
+class GraphBuildContext:
+    """Mutable container used while assembling a payload."""
+
+    nodes: Dict[str, GraphNodeSpec] = field(default_factory=dict)
+    edges: list[GraphEdgeSpec] = field(default_factory=list)
+
+    def add_node(self, label: str, properties: Dict[str, Any]) -> GraphNodeSpec:
+        """Create and add a node to the context. Returns the node spec."""
+        props = clean_props(properties)
+        if not props:
+            raise ValueError(f"{label} node requires at least one property")
+
+        key = _make_key(label, props)
+        node = GraphNodeSpec(label=label, key=key, properties=props)
+        return self._upsert(node)
+
+    def _upsert(self, node: GraphNodeSpec) -> GraphNodeSpec:
+        """Add node, merging properties if key already exists."""
+        if existing := self.nodes.get(node.key):
+            merged = {**existing.properties, **node.properties}
+            node = GraphNodeSpec(node.label, node.key, merged)
+        self.nodes[node.key] = node
+        return node
+
+    def add_edge(self, edge_type: str, source: str, target: str) -> None:
+        """Add a directed edge between two node keys."""
+        self.edges.append(GraphEdgeSpec(edge_type, source, target))
+
+    def to_payload(self) -> GraphPayload:
+        """Finalize the context into an immutable payload."""
+        return GraphPayload(
+            nodes=tuple(self.nodes.values()),
+            edges=tuple(_dedup_edges(self.edges)),
+        )
+
+
+def _make_key(label: str, props: Dict[str, Any]) -> str:
+    """Generate internal key for edge connections within a payload.
+
+    This key is NOT used for Neo4j identity - that's handled by constraints.
+    Uses content hash for simplicity and determinism.
+    """
+    digest = hashlib.sha1(
+        json.dumps(props, sort_keys=True, ensure_ascii=False).encode()
+    ).hexdigest()
+    return f"{label}::{digest[:12]}"
+
+
+def clean_props(props: Dict[str, Any]) -> Dict[str, Any]:
+    """Remove empty values and strip strings."""
+    return {
+        k: (v.strip() if isinstance(v, str) else v)
+        for k, v in props.items()
+        if v is not None and (not isinstance(v, str) or v.strip())
+    }
+
+
+def _dedup_edges(edges: Iterable[GraphEdgeSpec]) -> Iterable[GraphEdgeSpec]:
+    seen: set[tuple[str, str, str]] = set()
+    for edge in edges:
+        key = (edge.type, edge.source, edge.target)
+        if key not in seen:
+            seen.add(key)
+            yield edge

--- a/src/stockelper_kg/graph/schema.py
+++ b/src/stockelper_kg/graph/schema.py
@@ -1,21 +1,13 @@
-"""Graph data structures and construction primitives.
-
-This module defines the low-level building blocks for the Knowledge Graph.
-Identity/uniqueness is handled by Neo4j constraints, not client-side logic.
-"""
-
 from __future__ import annotations
 
 import hashlib
 import json
 from dataclasses import asdict, dataclass, field
-from typing import Any, Dict, Iterable, Tuple
+from typing import Any, Dict, Tuple
 
 
 @dataclass(frozen=True)
 class GraphNodeSpec:
-    """Node specification for graph operations."""
-
     label: str
     key: str
     properties: Dict[str, Any]
@@ -24,8 +16,6 @@ class GraphNodeSpec:
 
 @dataclass(frozen=True)
 class GraphEdgeSpec:
-    """Edge specification for graph operations."""
-
     type: str
     source: str
     target: str
@@ -33,8 +23,6 @@ class GraphEdgeSpec:
 
 @dataclass(frozen=True)
 class GraphPayload:
-    """Immutable collection of nodes and edges."""
-
     nodes: Tuple[GraphNodeSpec, ...]
     edges: Tuple[GraphEdgeSpec, ...]
 
@@ -55,47 +43,37 @@ class GraphPayload:
 
 @dataclass
 class GraphBuildContext:
-    """Mutable container used while assembling a payload."""
-
     nodes: Dict[str, GraphNodeSpec] = field(default_factory=dict)
     edges: list[GraphEdgeSpec] = field(default_factory=list)
 
     def add_node(self, label: str, properties: Dict[str, Any]) -> GraphNodeSpec:
-        """Create and add a node to the context. Returns the node spec."""
         props = clean_props(properties)
         if not props:
             raise ValueError(f"{label} node requires at least one property")
-
         key = _make_key(label, props)
-        node = GraphNodeSpec(label=label, key=key, properties=props)
-        return self._upsert(node)
-
-    def _upsert(self, node: GraphNodeSpec) -> GraphNodeSpec:
-        """Add node, merging properties if key already exists."""
-        if existing := self.nodes.get(node.key):
-            merged = {**existing.properties, **node.properties}
-            node = GraphNodeSpec(node.label, node.key, merged)
+        node = GraphNodeSpec(label, key, props)
+        if existing := self.nodes.get(key):
+            merged = {**existing.properties, **props}
+            node = GraphNodeSpec(node.label, key, merged)
         self.nodes[node.key] = node
         return node
 
     def add_edge(self, edge_type: str, source: str, target: str) -> None:
-        """Add a directed edge between two node keys."""
         self.edges.append(GraphEdgeSpec(edge_type, source, target))
 
     def to_payload(self) -> GraphPayload:
-        """Finalize the context into an immutable payload."""
-        return GraphPayload(
-            nodes=tuple(self.nodes.values()),
-            edges=tuple(_dedup_edges(self.edges)),
-        )
+        seen: set[tuple[str, str, str]] = set()
+        deduped = []
+        for edge in self.edges:
+            key = (edge.type, edge.source, edge.target)
+            if key in seen:
+                continue
+            seen.add(key)
+            deduped.append(edge)
+        return GraphPayload(nodes=tuple(self.nodes.values()), edges=tuple(deduped))
 
 
 def _make_key(label: str, props: Dict[str, Any]) -> str:
-    """Generate internal key for edge connections within a payload.
-
-    This key is NOT used for Neo4j identity - that's handled by constraints.
-    Uses content hash for simplicity and determinism.
-    """
     digest = hashlib.sha1(
         json.dumps(props, sort_keys=True, ensure_ascii=False).encode()
     ).hexdigest()
@@ -103,18 +81,8 @@ def _make_key(label: str, props: Dict[str, Any]) -> str:
 
 
 def clean_props(props: Dict[str, Any]) -> Dict[str, Any]:
-    """Remove empty values and strip strings."""
     return {
         k: (v.strip() if isinstance(v, str) else v)
         for k, v in props.items()
         if v is not None and (not isinstance(v, str) or v.strip())
     }
-
-
-def _dedup_edges(edges: Iterable[GraphEdgeSpec]) -> Iterable[GraphEdgeSpec]:
-    seen: set[tuple[str, str, str]] = set()
-    for edge in edges:
-        key = (edge.type, edge.source, edge.target)
-        if key not in seen:
-            seen.add(key)
-            yield edge

--- a/src/stockelper_kg/pipeline.py
+++ b/src/stockelper_kg/pipeline.py
@@ -42,12 +42,10 @@ class EventPipeline:
         event_text: str,
         metadata: dict[str, Any] | None = None,
     ) -> dict[str, Any]:
-        result = self._analyze(event_text)
+        result = self._analyze(event_text, metadata)
         self._save_event(result.event_data, metadata)
-
         if result.stock_code and result.date:
             self._save_company(result.stock_code, result.date)
-
         return result.event_data
 
     def _create_collector(self, config: Config) -> EventCollector:
@@ -60,7 +58,9 @@ class EventPipeline:
             competitors=MongoDBCollector(config.mongodb),
         )
 
-    def _analyze(self, text: str) -> EventResult:
+    def _analyze(
+        self, text: str, metadata: dict[str, Any] | None = None
+    ) -> EventResult:
         logger.info("Analyzing event...")
         event_data = classify_event(text)
 
@@ -69,28 +69,24 @@ class EventPipeline:
             slots = {}
             event_data["required_slots"] = slots
 
-        corp_name = event_data.get("corp_name", "").strip()
+        corp_name = (event_data.get("corp_name") or "").strip()
+        if not corp_name and metadata:
+            corp_name = (metadata.get("corp_name") or "").strip()
         if not corp_name:
             raise ValueError("corp_name is required")
         slots["corp_name"] = corp_name
+        event_data["corp_name"] = corp_name
 
-        raw_date = slots.get("date") or event_data.get("date")
-        if raw_date:
-            canonical_date = normalize_date(raw_date)
-            if canonical_date:
-                slots["date"] = canonical_date
-                event_data["date"] = canonical_date
+        if raw_date := slots.get("date") or event_data.get("date"):
+            if normalized_date := normalize_date(raw_date):
+                slots["date"] = event_data["date"] = normalized_date
 
-        stock_code = slots.get("stock_code")
-        if not stock_code:
-            stock_code = self.collector.resolve(corp_name)
+        stock_code = slots.get("stock_code") or self.collector.resolve(corp_name)
         if stock_code:
             slots["stock_code"] = stock_code
 
         return EventResult(
-            event_data=event_data,
-            stock_code=stock_code,
-            date=slots.get("date"),
+            event_data=event_data, stock_code=stock_code, date=slots.get("date")
         )
 
     def _save_event(
@@ -98,18 +94,7 @@ class EventPipeline:
         event_data: dict[str, Any],
         metadata: dict[str, Any] | None,
     ) -> None:
-        slots = event_data.get("required_slots", {})
-        if not isinstance(slots, dict):
-            slots = {}
-            event_data["required_slots"] = slots
-
-        corp_name = event_data.get("corp_name", "").strip()
-        if not corp_name and metadata:
-            corp_name = (metadata.get("corp_name") or "").strip()
-        if not corp_name:
-            raise ValueError("corp_name is required")
-        slots["corp_name"] = corp_name
-
+        corp_name = event_data.get("corp_name")
         logger.info("[%s] Saving event graph...", corp_name)
         payload = build_graph_payload(event_data, metadata=metadata)
         cypher = payload_to_cypher(payload)

--- a/src/stockelper_kg/pipeline.py
+++ b/src/stockelper_kg/pipeline.py
@@ -1,0 +1,133 @@
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Any
+
+from .collectors.dart import DartCollector
+from .collectors.event import EventCollector
+from .collectors.kis import KISCollector
+from .collectors.krx import KRXCollector
+from .collectors.mongodb import MongoDBCollector
+from .config import Config
+from .graph import GraphBuilder, Neo4jClient
+from .graph.cypher import payload_to_cypher
+from .graph.event import classify_event
+from .graph.payload import build_graph_payload
+from .utils.dates import normalize_date
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class EventResult:
+    event_data: dict[str, Any]
+    stock_code: str | None = None
+    date: str | None = None
+
+
+class EventPipeline:
+    def __init__(
+        self,
+        config: Config,
+        neo4j_client: Neo4jClient,
+        collector: EventCollector | None = None,
+    ):
+        self.client = neo4j_client
+        self.graph_builder = GraphBuilder(neo4j_client)
+        self.collector = collector or self._create_collector(config)
+
+    def process(
+        self,
+        event_text: str,
+        metadata: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        result = self._analyze(event_text)
+        self._save_event(result.event_data, metadata)
+
+        if result.stock_code and result.date:
+            self._save_company(result.stock_code, result.date)
+
+        return result.event_data
+
+    def _create_collector(self, config: Config) -> EventCollector:
+        return EventCollector(
+            dart=DartCollector(config.dart_api_key, config.sleep_seconds),
+            kis=KISCollector(
+                config.kis, config.sleep_seconds, getattr(config, "env_path", ".env")
+            ),
+            krx=KRXCollector(config.sleep_seconds),
+            competitors=MongoDBCollector(config.mongodb),
+        )
+
+    def _analyze(self, text: str) -> EventResult:
+        logger.info("Analyzing event...")
+        event_data = classify_event(text)
+
+        slots = event_data.get("required_slots", {})
+        if not isinstance(slots, dict):
+            slots = {}
+            event_data["required_slots"] = slots
+
+        corp_name = event_data.get("corp_name", "").strip()
+        if not corp_name:
+            raise ValueError("corp_name is required")
+        slots["corp_name"] = corp_name
+
+        raw_date = slots.get("date") or event_data.get("date")
+        if raw_date:
+            canonical_date = normalize_date(raw_date)
+            if canonical_date:
+                slots["date"] = canonical_date
+                event_data["date"] = canonical_date
+
+        stock_code = slots.get("stock_code")
+        if not stock_code:
+            stock_code = self.collector.resolve(corp_name)
+        if stock_code:
+            slots["stock_code"] = stock_code
+
+        return EventResult(
+            event_data=event_data,
+            stock_code=stock_code,
+            date=slots.get("date"),
+        )
+
+    def _save_event(
+        self,
+        event_data: dict[str, Any],
+        metadata: dict[str, Any] | None,
+    ) -> None:
+        slots = event_data.get("required_slots", {})
+        if not isinstance(slots, dict):
+            slots = {}
+            event_data["required_slots"] = slots
+
+        corp_name = event_data.get("corp_name", "").strip()
+        if not corp_name and metadata:
+            corp_name = (metadata.get("corp_name") or "").strip()
+        if not corp_name:
+            raise ValueError("corp_name is required")
+        slots["corp_name"] = corp_name
+
+        logger.info("[%s] Saving event graph...", corp_name)
+        payload = build_graph_payload(event_data, metadata=metadata)
+        cypher = payload_to_cypher(payload)
+        self.client.execute_query(cypher)
+
+    def _save_company(self, stock_code: str, date: str) -> None:
+        logger.info("[%s] Collecting company data...", stock_code)
+        try:
+            df = self.collector.collect(stock_code, date)
+            if df.empty:
+                logger.warning("[%s] No data collected", stock_code)
+                return
+
+            self.graph_builder.build_graph(df, stock_code, [date])
+            logger.info("[%s] Graph updated", stock_code)
+        except Exception as e:
+            logger.error("[%s] Failed to update company graph: %s", stock_code, e)
+
+
+def create_pipeline(config: Config) -> EventPipeline:
+    return EventPipeline(config, Neo4jClient(config.neo4j))

--- a/src/stockelper_kg/utils/dates.py
+++ b/src/stockelper_kg/utils/dates.py
@@ -1,7 +1,59 @@
 """Date utility functions."""
 
+from __future__ import annotations
+
 from datetime import datetime, timedelta
-from typing import List
+from typing import Any, Dict, List, Optional
+
+
+def normalize_date(value: Any) -> Optional[str]:
+    """Normalize input to YYYY-MM-DD string format.
+
+    Handles YYYY-MM-DD, YYYY/MM/DD, YYYYMMDD strings, and other common formats.
+    Returns None if normalization fails or input is empty.
+    """
+    if value is None:
+        return None
+    text = str(value).strip()
+    if not text:
+        return None
+    digits = "".join(ch for ch in text if ch.isdigit())
+    if len(digits) != 8:
+        return None
+
+    try:
+        return datetime.strptime(digits, "%Y%m%d").strftime("%Y-%m-%d")
+    except ValueError:
+        return None
+
+
+def build_date_properties(value: Any) -> Optional[Dict[str, Any]]:
+    """Build canonical Date node properties from flexible input.
+
+    - Accepts strings like YYYY-MM-DD, YYYY/MM/DD, YYYYMMDD, etc.
+    - Returns a mapping that always includes:
+        - "date": YYYY-MM-DD
+        - "formatted_date": YYYY-MM-DD
+        - "year", "month", "day": integers
+    - Returns None if the input cannot be normalised to a valid date.
+    """
+    canonical = normalize_date(value)
+    if not canonical:
+        return None
+
+    try:
+        dt = datetime.strptime(canonical, "%Y-%m-%d")
+    except ValueError:
+        # Guard against impossible dates that slipped through normalize_date
+        return None
+
+    return {
+        "date": canonical,
+        "formatted_date": canonical,
+        "year": dt.year,
+        "month": dt.month,
+        "day": dt.day,
+    }
 
 
 def get_date_list(date_st: str, date_fn: str) -> List[str]:

--- a/uv.lock
+++ b/uv.lock
@@ -1,6 +1,28 @@
 version = 1
-revision = 1
+revision = 2
 requires-python = "==3.12.*"
+
+[[package]]
+name = "annotated-types"
+version = "0.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ee/67/531ea369ba64dcff5ec9c3402f9f51bf748cec26dde048a2f973a4eea7f5/annotated_types-0.7.0.tar.gz", hash = "sha256:aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89", size = 16081, upload-time = "2024-05-20T21:33:25.928Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl", hash = "sha256:1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53", size = 13643, upload-time = "2024-05-20T21:33:24.1Z" },
+]
+
+[[package]]
+name = "anyio"
+version = "4.12.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "idna" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/16/ce/8a777047513153587e5434fd752e89334ac33e379aa3497db860eeb60377/anyio-4.12.0.tar.gz", hash = "sha256:73c693b567b0c55130c104d0b43a9baf3aa6a31fc6110116509f27bf75e21ec0", size = 228266, upload-time = "2025-11-28T23:37:38.911Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7f/9c/36c5c37947ebfb8c7f22e0eb6e4d188ee2d53aa3880f3f2744fb894f0cb1/anyio-4.12.0-py3-none-any.whl", hash = "sha256:dad2376a628f98eeca4881fc56cd06affd18f659b17a747d3ff0307ced94b1bb", size = 113362, upload-time = "2025-11-28T23:36:57.897Z" },
+]
 
 [[package]]
 name = "beautifulsoup4"
@@ -10,9 +32,9 @@ dependencies = [
     { name = "soupsieve" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/85/2e/3e5079847e653b1f6dc647aa24549d68c6addb4c595cc0d902d1b19308ad/beautifulsoup4-4.13.5.tar.gz", hash = "sha256:5e70131382930e7c3de33450a2f54a63d5e4b19386eab43a5b34d594268f3695", size = 622954 }
+sdist = { url = "https://files.pythonhosted.org/packages/85/2e/3e5079847e653b1f6dc647aa24549d68c6addb4c595cc0d902d1b19308ad/beautifulsoup4-4.13.5.tar.gz", hash = "sha256:5e70131382930e7c3de33450a2f54a63d5e4b19386eab43a5b34d594268f3695", size = 622954, upload-time = "2025-08-24T14:06:13.168Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/04/eb/f4151e0c7377a6e08a38108609ba5cede57986802757848688aeedd1b9e8/beautifulsoup4-4.13.5-py3-none-any.whl", hash = "sha256:642085eaa22233aceadff9c69651bc51e8bf3f874fb6d7104ece2beb24b47c4a", size = 105113 },
+    { url = "https://files.pythonhosted.org/packages/04/eb/f4151e0c7377a6e08a38108609ba5cede57986802757848688aeedd1b9e8/beautifulsoup4-4.13.5-py3-none-any.whl", hash = "sha256:642085eaa22233aceadff9c69651bc51e8bf3f874fb6d7104ece2beb24b47c4a", size = 105113, upload-time = "2025-08-24T14:06:14.884Z" },
 ]
 
 [[package]]
@@ -26,42 +48,42 @@ dependencies = [
     { name = "pathspec" },
     { name = "platformdirs" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/fd/f4/a57cde4b60da0e249073009f4a9087e9e0a955deae78d3c2a493208d0c5c/black-23.12.1.tar.gz", hash = "sha256:4ce3ef14ebe8d9509188014d96af1c456a910d5b5cbf434a09fef7e024b3d0d5", size = 620809 }
+sdist = { url = "https://files.pythonhosted.org/packages/fd/f4/a57cde4b60da0e249073009f4a9087e9e0a955deae78d3c2a493208d0c5c/black-23.12.1.tar.gz", hash = "sha256:4ce3ef14ebe8d9509188014d96af1c456a910d5b5cbf434a09fef7e024b3d0d5", size = 620809, upload-time = "2023-12-22T23:06:17.382Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/66/16/8726cedc83be841dfa854bbeef1288ee82272282a71048d7935292182b0b/black-23.12.1-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:25e57fd232a6d6ff3f4478a6fd0580838e47c93c83eaf1ccc92d4faf27112c4e", size = 1569989 },
-    { url = "https://files.pythonhosted.org/packages/d2/1e/30f5eafcc41b8378890ba39b693fa111f7dca8a2620ba5162075d95ffe46/black-23.12.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:2d9e13db441c509a3763a7a3d9a49ccc1b4e974a47be4e08ade2a228876500ec", size = 1398647 },
-    { url = "https://files.pythonhosted.org/packages/99/de/ddb45cc044256431d96d846ce03164d149d81ca606b5172224d1872e0b58/black-23.12.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6d1bd9c210f8b109b1762ec9fd36592fdd528485aadb3f5849b2740ef17e674e", size = 1720450 },
-    { url = "https://files.pythonhosted.org/packages/98/2b/54e5dbe9be5a10cbea2259517206ff7b6a452bb34e07508c7e1395950833/black-23.12.1-cp312-cp312-win_amd64.whl", hash = "sha256:ae76c22bde5cbb6bfd211ec343ded2163bba7883c7bc77f6b756a1049436fbb9", size = 1351070 },
-    { url = "https://files.pythonhosted.org/packages/7b/14/4da7b12a9abc43a601c215cb5a3d176734578da109f0dbf0a832ed78be09/black-23.12.1-py3-none-any.whl", hash = "sha256:78baad24af0f033958cad29731e27363183e140962595def56423e626f4bee3e", size = 194363 },
+    { url = "https://files.pythonhosted.org/packages/66/16/8726cedc83be841dfa854bbeef1288ee82272282a71048d7935292182b0b/black-23.12.1-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:25e57fd232a6d6ff3f4478a6fd0580838e47c93c83eaf1ccc92d4faf27112c4e", size = 1569989, upload-time = "2023-12-22T23:20:22.158Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/1e/30f5eafcc41b8378890ba39b693fa111f7dca8a2620ba5162075d95ffe46/black-23.12.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:2d9e13db441c509a3763a7a3d9a49ccc1b4e974a47be4e08ade2a228876500ec", size = 1398647, upload-time = "2023-12-22T23:19:57.225Z" },
+    { url = "https://files.pythonhosted.org/packages/99/de/ddb45cc044256431d96d846ce03164d149d81ca606b5172224d1872e0b58/black-23.12.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6d1bd9c210f8b109b1762ec9fd36592fdd528485aadb3f5849b2740ef17e674e", size = 1720450, upload-time = "2023-12-22T23:08:52.675Z" },
+    { url = "https://files.pythonhosted.org/packages/98/2b/54e5dbe9be5a10cbea2259517206ff7b6a452bb34e07508c7e1395950833/black-23.12.1-cp312-cp312-win_amd64.whl", hash = "sha256:ae76c22bde5cbb6bfd211ec343ded2163bba7883c7bc77f6b756a1049436fbb9", size = 1351070, upload-time = "2023-12-22T23:09:32.762Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/14/4da7b12a9abc43a601c215cb5a3d176734578da109f0dbf0a832ed78be09/black-23.12.1-py3-none-any.whl", hash = "sha256:78baad24af0f033958cad29731e27363183e140962595def56423e626f4bee3e", size = 194363, upload-time = "2023-12-22T23:06:14.278Z" },
 ]
 
 [[package]]
 name = "certifi"
 version = "2025.8.3"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/dc/67/960ebe6bf230a96cda2e0abcf73af550ec4f090005363542f0765df162e0/certifi-2025.8.3.tar.gz", hash = "sha256:e564105f78ded564e3ae7c923924435e1daa7463faeab5bb932bc53ffae63407", size = 162386 }
+sdist = { url = "https://files.pythonhosted.org/packages/dc/67/960ebe6bf230a96cda2e0abcf73af550ec4f090005363542f0765df162e0/certifi-2025.8.3.tar.gz", hash = "sha256:e564105f78ded564e3ae7c923924435e1daa7463faeab5bb932bc53ffae63407", size = 162386, upload-time = "2025-08-03T03:07:47.08Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e5/48/1549795ba7742c948d2ad169c1c8cdbae65bc450d6cd753d124b17c8cd32/certifi-2025.8.3-py3-none-any.whl", hash = "sha256:f6c12493cfb1b06ba2ff328595af9350c65d6644968e5d3a2ffd78699af217a5", size = 161216 },
+    { url = "https://files.pythonhosted.org/packages/e5/48/1549795ba7742c948d2ad169c1c8cdbae65bc450d6cd753d124b17c8cd32/certifi-2025.8.3-py3-none-any.whl", hash = "sha256:f6c12493cfb1b06ba2ff328595af9350c65d6644968e5d3a2ffd78699af217a5", size = 161216, upload-time = "2025-08-03T03:07:45.777Z" },
 ]
 
 [[package]]
 name = "charset-normalizer"
 version = "3.4.3"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/83/2d/5fd176ceb9b2fc619e63405525573493ca23441330fcdaee6bef9460e924/charset_normalizer-3.4.3.tar.gz", hash = "sha256:6fce4b8500244f6fcb71465d4a4930d132ba9ab8e71a7859e6a5d59851068d14", size = 122371 }
+sdist = { url = "https://files.pythonhosted.org/packages/83/2d/5fd176ceb9b2fc619e63405525573493ca23441330fcdaee6bef9460e924/charset_normalizer-3.4.3.tar.gz", hash = "sha256:6fce4b8500244f6fcb71465d4a4930d132ba9ab8e71a7859e6a5d59851068d14", size = 122371, upload-time = "2025-08-09T07:57:28.46Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e9/5e/14c94999e418d9b87682734589404a25854d5f5d0408df68bc15b6ff54bb/charset_normalizer-3.4.3-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:e28e334d3ff134e88989d90ba04b47d84382a828c061d0d1027b1b12a62b39b1", size = 205655 },
-    { url = "https://files.pythonhosted.org/packages/7d/a8/c6ec5d389672521f644505a257f50544c074cf5fc292d5390331cd6fc9c3/charset_normalizer-3.4.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0cacf8f7297b0c4fcb74227692ca46b4a5852f8f4f24b3c766dd94a1075c4884", size = 146223 },
-    { url = "https://files.pythonhosted.org/packages/fc/eb/a2ffb08547f4e1e5415fb69eb7db25932c52a52bed371429648db4d84fb1/charset_normalizer-3.4.3-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:c6fd51128a41297f5409deab284fecbe5305ebd7e5a1f959bee1c054622b7018", size = 159366 },
-    { url = "https://files.pythonhosted.org/packages/82/10/0fd19f20c624b278dddaf83b8464dcddc2456cb4b02bb902a6da126b87a1/charset_normalizer-3.4.3-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:3cfb2aad70f2c6debfbcb717f23b7eb55febc0bb23dcffc0f076009da10c6392", size = 157104 },
-    { url = "https://files.pythonhosted.org/packages/16/ab/0233c3231af734f5dfcf0844aa9582d5a1466c985bbed6cedab85af9bfe3/charset_normalizer-3.4.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1606f4a55c0fd363d754049cdf400175ee96c992b1f8018b993941f221221c5f", size = 151830 },
-    { url = "https://files.pythonhosted.org/packages/ae/02/e29e22b4e02839a0e4a06557b1999d0a47db3567e82989b5bb21f3fbbd9f/charset_normalizer-3.4.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:027b776c26d38b7f15b26a5da1044f376455fb3766df8fc38563b4efbc515154", size = 148854 },
-    { url = "https://files.pythonhosted.org/packages/05/6b/e2539a0a4be302b481e8cafb5af8792da8093b486885a1ae4d15d452bcec/charset_normalizer-3.4.3-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:42e5088973e56e31e4fa58eb6bd709e42fc03799c11c42929592889a2e54c491", size = 160670 },
-    { url = "https://files.pythonhosted.org/packages/31/e7/883ee5676a2ef217a40ce0bffcc3d0dfbf9e64cbcfbdf822c52981c3304b/charset_normalizer-3.4.3-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:cc34f233c9e71701040d772aa7490318673aa7164a0efe3172b2981218c26d93", size = 158501 },
-    { url = "https://files.pythonhosted.org/packages/c1/35/6525b21aa0db614cf8b5792d232021dca3df7f90a1944db934efa5d20bb1/charset_normalizer-3.4.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:320e8e66157cc4e247d9ddca8e21f427efc7a04bbd0ac8a9faf56583fa543f9f", size = 153173 },
-    { url = "https://files.pythonhosted.org/packages/50/ee/f4704bad8201de513fdc8aac1cabc87e38c5818c93857140e06e772b5892/charset_normalizer-3.4.3-cp312-cp312-win32.whl", hash = "sha256:fb6fecfd65564f208cbf0fba07f107fb661bcd1a7c389edbced3f7a493f70e37", size = 99822 },
-    { url = "https://files.pythonhosted.org/packages/39/f5/3b3836ca6064d0992c58c7561c6b6eee1b3892e9665d650c803bd5614522/charset_normalizer-3.4.3-cp312-cp312-win_amd64.whl", hash = "sha256:86df271bf921c2ee3818f0522e9a5b8092ca2ad8b065ece5d7d9d0e9f4849bcc", size = 107543 },
-    { url = "https://files.pythonhosted.org/packages/8a/1f/f041989e93b001bc4e44bb1669ccdcf54d3f00e628229a85b08d330615c5/charset_normalizer-3.4.3-py3-none-any.whl", hash = "sha256:ce571ab16d890d23b5c278547ba694193a45011ff86a9162a71307ed9f86759a", size = 53175 },
+    { url = "https://files.pythonhosted.org/packages/e9/5e/14c94999e418d9b87682734589404a25854d5f5d0408df68bc15b6ff54bb/charset_normalizer-3.4.3-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:e28e334d3ff134e88989d90ba04b47d84382a828c061d0d1027b1b12a62b39b1", size = 205655, upload-time = "2025-08-09T07:56:08.475Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/a8/c6ec5d389672521f644505a257f50544c074cf5fc292d5390331cd6fc9c3/charset_normalizer-3.4.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0cacf8f7297b0c4fcb74227692ca46b4a5852f8f4f24b3c766dd94a1075c4884", size = 146223, upload-time = "2025-08-09T07:56:09.708Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/eb/a2ffb08547f4e1e5415fb69eb7db25932c52a52bed371429648db4d84fb1/charset_normalizer-3.4.3-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:c6fd51128a41297f5409deab284fecbe5305ebd7e5a1f959bee1c054622b7018", size = 159366, upload-time = "2025-08-09T07:56:11.326Z" },
+    { url = "https://files.pythonhosted.org/packages/82/10/0fd19f20c624b278dddaf83b8464dcddc2456cb4b02bb902a6da126b87a1/charset_normalizer-3.4.3-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:3cfb2aad70f2c6debfbcb717f23b7eb55febc0bb23dcffc0f076009da10c6392", size = 157104, upload-time = "2025-08-09T07:56:13.014Z" },
+    { url = "https://files.pythonhosted.org/packages/16/ab/0233c3231af734f5dfcf0844aa9582d5a1466c985bbed6cedab85af9bfe3/charset_normalizer-3.4.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1606f4a55c0fd363d754049cdf400175ee96c992b1f8018b993941f221221c5f", size = 151830, upload-time = "2025-08-09T07:56:14.428Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/02/e29e22b4e02839a0e4a06557b1999d0a47db3567e82989b5bb21f3fbbd9f/charset_normalizer-3.4.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:027b776c26d38b7f15b26a5da1044f376455fb3766df8fc38563b4efbc515154", size = 148854, upload-time = "2025-08-09T07:56:16.051Z" },
+    { url = "https://files.pythonhosted.org/packages/05/6b/e2539a0a4be302b481e8cafb5af8792da8093b486885a1ae4d15d452bcec/charset_normalizer-3.4.3-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:42e5088973e56e31e4fa58eb6bd709e42fc03799c11c42929592889a2e54c491", size = 160670, upload-time = "2025-08-09T07:56:17.314Z" },
+    { url = "https://files.pythonhosted.org/packages/31/e7/883ee5676a2ef217a40ce0bffcc3d0dfbf9e64cbcfbdf822c52981c3304b/charset_normalizer-3.4.3-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:cc34f233c9e71701040d772aa7490318673aa7164a0efe3172b2981218c26d93", size = 158501, upload-time = "2025-08-09T07:56:18.641Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/35/6525b21aa0db614cf8b5792d232021dca3df7f90a1944db934efa5d20bb1/charset_normalizer-3.4.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:320e8e66157cc4e247d9ddca8e21f427efc7a04bbd0ac8a9faf56583fa543f9f", size = 153173, upload-time = "2025-08-09T07:56:20.289Z" },
+    { url = "https://files.pythonhosted.org/packages/50/ee/f4704bad8201de513fdc8aac1cabc87e38c5818c93857140e06e772b5892/charset_normalizer-3.4.3-cp312-cp312-win32.whl", hash = "sha256:fb6fecfd65564f208cbf0fba07f107fb661bcd1a7c389edbced3f7a493f70e37", size = 99822, upload-time = "2025-08-09T07:56:21.551Z" },
+    { url = "https://files.pythonhosted.org/packages/39/f5/3b3836ca6064d0992c58c7561c6b6eee1b3892e9665d650c803bd5614522/charset_normalizer-3.4.3-cp312-cp312-win_amd64.whl", hash = "sha256:86df271bf921c2ee3818f0522e9a5b8092ca2ad8b065ece5d7d9d0e9f4849bcc", size = 107543, upload-time = "2025-08-09T07:56:23.115Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/1f/f041989e93b001bc4e44bb1669ccdcf54d3f00e628229a85b08d330615c5/charset_normalizer-3.4.3-py3-none-any.whl", hash = "sha256:ce571ab16d890d23b5c278547ba694193a45011ff86a9162a71307ed9f86759a", size = 53175, upload-time = "2025-08-09T07:57:26.864Z" },
 ]
 
 [[package]]
@@ -71,49 +93,58 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/46/61/de6cd827efad202d7057d93e0fed9294b96952e188f7384832791c7b2254/click-8.3.0.tar.gz", hash = "sha256:e7b8232224eba16f4ebe410c25ced9f7875cb5f3263ffc93cc3e8da705e229c4", size = 276943 }
+sdist = { url = "https://files.pythonhosted.org/packages/46/61/de6cd827efad202d7057d93e0fed9294b96952e188f7384832791c7b2254/click-8.3.0.tar.gz", hash = "sha256:e7b8232224eba16f4ebe410c25ced9f7875cb5f3263ffc93cc3e8da705e229c4", size = 276943, upload-time = "2025-09-18T17:32:23.696Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/db/d3/9dcc0f5797f070ec8edf30fbadfb200e71d9db6b84d211e3b2085a7589a0/click-8.3.0-py3-none-any.whl", hash = "sha256:9b9f285302c6e3064f4330c05f05b81945b2a39544279343e6e7c5f27a9baddc", size = 107295 },
+    { url = "https://files.pythonhosted.org/packages/db/d3/9dcc0f5797f070ec8edf30fbadfb200e71d9db6b84d211e3b2085a7589a0/click-8.3.0-py3-none-any.whl", hash = "sha256:9b9f285302c6e3064f4330c05f05b81945b2a39544279343e6e7c5f27a9baddc", size = 107295, upload-time = "2025-09-18T17:32:22.42Z" },
 ]
 
 [[package]]
 name = "colorama"
 version = "0.4.6"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697 }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335 },
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
 ]
 
 [[package]]
 name = "coverage"
 version = "7.10.7"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/51/26/d22c300112504f5f9a9fd2297ce33c35f3d353e4aeb987c8419453b2a7c2/coverage-7.10.7.tar.gz", hash = "sha256:f4ab143ab113be368a3e9b795f9cd7906c5ef407d6173fe9675a902e1fffc239", size = 827704 }
+sdist = { url = "https://files.pythonhosted.org/packages/51/26/d22c300112504f5f9a9fd2297ce33c35f3d353e4aeb987c8419453b2a7c2/coverage-7.10.7.tar.gz", hash = "sha256:f4ab143ab113be368a3e9b795f9cd7906c5ef407d6173fe9675a902e1fffc239", size = 827704, upload-time = "2025-09-21T20:03:56.815Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/13/e4/eb12450f71b542a53972d19117ea5a5cea1cab3ac9e31b0b5d498df1bd5a/coverage-7.10.7-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:7bb3b9ddb87ef7725056572368040c32775036472d5a033679d1fa6c8dc08417", size = 218290 },
-    { url = "https://files.pythonhosted.org/packages/37/66/593f9be12fc19fb36711f19a5371af79a718537204d16ea1d36f16bd78d2/coverage-7.10.7-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:18afb24843cbc175687225cab1138c95d262337f5473512010e46831aa0c2973", size = 218515 },
-    { url = "https://files.pythonhosted.org/packages/66/80/4c49f7ae09cafdacc73fbc30949ffe77359635c168f4e9ff33c9ebb07838/coverage-7.10.7-cp312-cp312-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:399a0b6347bcd3822be369392932884b8216d0944049ae22925631a9b3d4ba4c", size = 250020 },
-    { url = "https://files.pythonhosted.org/packages/a6/90/a64aaacab3b37a17aaedd83e8000142561a29eb262cede42d94a67f7556b/coverage-7.10.7-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:314f2c326ded3f4b09be11bc282eb2fc861184bc95748ae67b360ac962770be7", size = 252769 },
-    { url = "https://files.pythonhosted.org/packages/98/2e/2dda59afd6103b342e096f246ebc5f87a3363b5412609946c120f4e7750d/coverage-7.10.7-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c41e71c9cfb854789dee6fc51e46743a6d138b1803fab6cb860af43265b42ea6", size = 253901 },
-    { url = "https://files.pythonhosted.org/packages/53/dc/8d8119c9051d50f3119bb4a75f29f1e4a6ab9415cd1fa8bf22fcc3fb3b5f/coverage-7.10.7-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:bc01f57ca26269c2c706e838f6422e2a8788e41b3e3c65e2f41148212e57cd59", size = 250413 },
-    { url = "https://files.pythonhosted.org/packages/98/b3/edaff9c5d79ee4d4b6d3fe046f2b1d799850425695b789d491a64225d493/coverage-7.10.7-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:a6442c59a8ac8b85812ce33bc4d05bde3fb22321fa8294e2a5b487c3505f611b", size = 251820 },
-    { url = "https://files.pythonhosted.org/packages/11/25/9a0728564bb05863f7e513e5a594fe5ffef091b325437f5430e8cfb0d530/coverage-7.10.7-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:78a384e49f46b80fb4c901d52d92abe098e78768ed829c673fbb53c498bef73a", size = 249941 },
-    { url = "https://files.pythonhosted.org/packages/e0/fd/ca2650443bfbef5b0e74373aac4df67b08180d2f184b482c41499668e258/coverage-7.10.7-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:5e1e9802121405ede4b0133aa4340ad8186a1d2526de5b7c3eca519db7bb89fb", size = 249519 },
-    { url = "https://files.pythonhosted.org/packages/24/79/f692f125fb4299b6f963b0745124998ebb8e73ecdfce4ceceb06a8c6bec5/coverage-7.10.7-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:d41213ea25a86f69efd1575073d34ea11aabe075604ddf3d148ecfec9e1e96a1", size = 251375 },
-    { url = "https://files.pythonhosted.org/packages/5e/75/61b9bbd6c7d24d896bfeec57acba78e0f8deac68e6baf2d4804f7aae1f88/coverage-7.10.7-cp312-cp312-win32.whl", hash = "sha256:77eb4c747061a6af8d0f7bdb31f1e108d172762ef579166ec84542f711d90256", size = 220699 },
-    { url = "https://files.pythonhosted.org/packages/ca/f3/3bf7905288b45b075918d372498f1cf845b5b579b723c8fd17168018d5f5/coverage-7.10.7-cp312-cp312-win_amd64.whl", hash = "sha256:f51328ffe987aecf6d09f3cd9d979face89a617eacdaea43e7b3080777f647ba", size = 221512 },
-    { url = "https://files.pythonhosted.org/packages/5c/44/3e32dbe933979d05cf2dac5e697c8599cfe038aaf51223ab901e208d5a62/coverage-7.10.7-cp312-cp312-win_arm64.whl", hash = "sha256:bda5e34f8a75721c96085903c6f2197dc398c20ffd98df33f866a9c8fd95f4bf", size = 220147 },
-    { url = "https://files.pythonhosted.org/packages/ec/16/114df1c291c22cac3b0c127a73e0af5c12ed7bbb6558d310429a0ae24023/coverage-7.10.7-py3-none-any.whl", hash = "sha256:f7941f6f2fe6dd6807a1208737b8a0cbcf1cc6d7b07d24998ad2d63590868260", size = 209952 },
+    { url = "https://files.pythonhosted.org/packages/13/e4/eb12450f71b542a53972d19117ea5a5cea1cab3ac9e31b0b5d498df1bd5a/coverage-7.10.7-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:7bb3b9ddb87ef7725056572368040c32775036472d5a033679d1fa6c8dc08417", size = 218290, upload-time = "2025-09-21T20:01:36.455Z" },
+    { url = "https://files.pythonhosted.org/packages/37/66/593f9be12fc19fb36711f19a5371af79a718537204d16ea1d36f16bd78d2/coverage-7.10.7-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:18afb24843cbc175687225cab1138c95d262337f5473512010e46831aa0c2973", size = 218515, upload-time = "2025-09-21T20:01:37.982Z" },
+    { url = "https://files.pythonhosted.org/packages/66/80/4c49f7ae09cafdacc73fbc30949ffe77359635c168f4e9ff33c9ebb07838/coverage-7.10.7-cp312-cp312-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:399a0b6347bcd3822be369392932884b8216d0944049ae22925631a9b3d4ba4c", size = 250020, upload-time = "2025-09-21T20:01:39.617Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/90/a64aaacab3b37a17aaedd83e8000142561a29eb262cede42d94a67f7556b/coverage-7.10.7-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:314f2c326ded3f4b09be11bc282eb2fc861184bc95748ae67b360ac962770be7", size = 252769, upload-time = "2025-09-21T20:01:41.341Z" },
+    { url = "https://files.pythonhosted.org/packages/98/2e/2dda59afd6103b342e096f246ebc5f87a3363b5412609946c120f4e7750d/coverage-7.10.7-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c41e71c9cfb854789dee6fc51e46743a6d138b1803fab6cb860af43265b42ea6", size = 253901, upload-time = "2025-09-21T20:01:43.042Z" },
+    { url = "https://files.pythonhosted.org/packages/53/dc/8d8119c9051d50f3119bb4a75f29f1e4a6ab9415cd1fa8bf22fcc3fb3b5f/coverage-7.10.7-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:bc01f57ca26269c2c706e838f6422e2a8788e41b3e3c65e2f41148212e57cd59", size = 250413, upload-time = "2025-09-21T20:01:44.469Z" },
+    { url = "https://files.pythonhosted.org/packages/98/b3/edaff9c5d79ee4d4b6d3fe046f2b1d799850425695b789d491a64225d493/coverage-7.10.7-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:a6442c59a8ac8b85812ce33bc4d05bde3fb22321fa8294e2a5b487c3505f611b", size = 251820, upload-time = "2025-09-21T20:01:45.915Z" },
+    { url = "https://files.pythonhosted.org/packages/11/25/9a0728564bb05863f7e513e5a594fe5ffef091b325437f5430e8cfb0d530/coverage-7.10.7-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:78a384e49f46b80fb4c901d52d92abe098e78768ed829c673fbb53c498bef73a", size = 249941, upload-time = "2025-09-21T20:01:47.296Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/fd/ca2650443bfbef5b0e74373aac4df67b08180d2f184b482c41499668e258/coverage-7.10.7-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:5e1e9802121405ede4b0133aa4340ad8186a1d2526de5b7c3eca519db7bb89fb", size = 249519, upload-time = "2025-09-21T20:01:48.73Z" },
+    { url = "https://files.pythonhosted.org/packages/24/79/f692f125fb4299b6f963b0745124998ebb8e73ecdfce4ceceb06a8c6bec5/coverage-7.10.7-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:d41213ea25a86f69efd1575073d34ea11aabe075604ddf3d148ecfec9e1e96a1", size = 251375, upload-time = "2025-09-21T20:01:50.529Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/75/61b9bbd6c7d24d896bfeec57acba78e0f8deac68e6baf2d4804f7aae1f88/coverage-7.10.7-cp312-cp312-win32.whl", hash = "sha256:77eb4c747061a6af8d0f7bdb31f1e108d172762ef579166ec84542f711d90256", size = 220699, upload-time = "2025-09-21T20:01:51.941Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/f3/3bf7905288b45b075918d372498f1cf845b5b579b723c8fd17168018d5f5/coverage-7.10.7-cp312-cp312-win_amd64.whl", hash = "sha256:f51328ffe987aecf6d09f3cd9d979face89a617eacdaea43e7b3080777f647ba", size = 221512, upload-time = "2025-09-21T20:01:53.481Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/44/3e32dbe933979d05cf2dac5e697c8599cfe038aaf51223ab901e208d5a62/coverage-7.10.7-cp312-cp312-win_arm64.whl", hash = "sha256:bda5e34f8a75721c96085903c6f2197dc398c20ffd98df33f866a9c8fd95f4bf", size = 220147, upload-time = "2025-09-21T20:01:55.2Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/16/114df1c291c22cac3b0c127a73e0af5c12ed7bbb6558d310429a0ae24023/coverage-7.10.7-py3-none-any.whl", hash = "sha256:f7941f6f2fe6dd6807a1208737b8a0cbcf1cc6d7b07d24998ad2d63590868260", size = 209952, upload-time = "2025-09-21T20:03:53.918Z" },
+]
+
+[[package]]
+name = "distro"
+version = "1.9.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fc/f8/98eea607f65de6527f8a2e8885fc8015d3e6f5775df186e443e0964a11c3/distro-1.9.0.tar.gz", hash = "sha256:2fa77c6fd8940f116ee1d6b94a2f90b13b5ea8d019b98bc8bafdcabcdd9bdbed", size = 60722, upload-time = "2023-12-24T09:54:32.31Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/12/b3/231ffd4ab1fc9d679809f356cebee130ac7daa00d6d6f3206dd4fd137e9e/distro-1.9.0-py3-none-any.whl", hash = "sha256:7bffd925d65168f85027d8da9af6bddab658135b840670a223589bc0c8ef02b2", size = 20277, upload-time = "2023-12-24T09:54:30.421Z" },
 ]
 
 [[package]]
 name = "dnspython"
 version = "2.8.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/8c/8b/57666417c0f90f08bcafa776861060426765fdb422eb10212086fb811d26/dnspython-2.8.0.tar.gz", hash = "sha256:181d3c6996452cb1189c4046c61599b84a5a86e099562ffde77d26984ff26d0f", size = 368251 }
+sdist = { url = "https://files.pythonhosted.org/packages/8c/8b/57666417c0f90f08bcafa776861060426765fdb422eb10212086fb811d26/dnspython-2.8.0.tar.gz", hash = "sha256:181d3c6996452cb1189c4046c61599b84a5a86e099562ffde77d26984ff26d0f", size = 368251, upload-time = "2025-09-07T18:58:00.022Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ba/5a/18ad964b0086c6e62e2e7500f7edc89e3faa45033c71c1893d34eed2b2de/dnspython-2.8.0-py3-none-any.whl", hash = "sha256:01d9bbc4a2d76bf0db7c1f729812ded6d912bd318d3b1cf81d30c0f845dbf3af", size = 331094 },
+    { url = "https://files.pythonhosted.org/packages/ba/5a/18ad964b0086c6e62e2e7500f7edc89e3faa45033c71c1893d34eed2b2de/dnspython-2.8.0-py3-none-any.whl", hash = "sha256:01d9bbc4a2d76bf0db7c1f729812ded6d912bd318d3b1cf81d30c0f845dbf3af", size = 331094, upload-time = "2025-09-07T18:57:58.071Z" },
 ]
 
 [[package]]
@@ -130,7 +161,7 @@ dependencies = [
     { name = "tqdm" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f1/a3/ef73e35c92b457d6cb501d4176ce580a87c8745febaedf1bafe20cff26cc/finance_datareader-0.9.96-py3-none-any.whl", hash = "sha256:c0e2c420932a05187042a25229e86bd312da162b5cd1f5e33990636071c3725c", size = 48217 },
+    { url = "https://files.pythonhosted.org/packages/f1/a3/ef73e35c92b457d6cb501d4176ce580a87c8745febaedf1bafe20cff26cc/finance_datareader-0.9.96-py3-none-any.whl", hash = "sha256:c0e2c420932a05187042a25229e86bd312da162b5cd1f5e33990636071c3725c", size = 48217, upload-time = "2025-02-13T13:31:24.8Z" },
 ]
 
 [[package]]
@@ -142,71 +173,133 @@ dependencies = [
     { name = "pycodestyle" },
     { name = "pyflakes" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/cf/f8/bbe24f43695c0c480181e39ce910c2650c794831886ec46ddd7c40520e6a/flake8-6.1.0.tar.gz", hash = "sha256:d5b3857f07c030bdb5bf41c7f53799571d75c4491748a3adcd47de929e34cd23", size = 48767 }
+sdist = { url = "https://files.pythonhosted.org/packages/cf/f8/bbe24f43695c0c480181e39ce910c2650c794831886ec46ddd7c40520e6a/flake8-6.1.0.tar.gz", hash = "sha256:d5b3857f07c030bdb5bf41c7f53799571d75c4491748a3adcd47de929e34cd23", size = 48767, upload-time = "2023-07-29T19:05:05.665Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b0/24/bbf7175ffc47cb3d3e1eb523ddb23272968359dfcf2e1294707a2bf12fc4/flake8-6.1.0-py2.py3-none-any.whl", hash = "sha256:ffdfce58ea94c6580c77888a86506937f9a1a227dfcd15f245d694ae20a6b6e5", size = 58260 },
+    { url = "https://files.pythonhosted.org/packages/b0/24/bbf7175ffc47cb3d3e1eb523ddb23272968359dfcf2e1294707a2bf12fc4/flake8-6.1.0-py2.py3-none-any.whl", hash = "sha256:ffdfce58ea94c6580c77888a86506937f9a1a227dfcd15f245d694ae20a6b6e5", size = 58260, upload-time = "2023-07-29T19:05:02.783Z" },
+]
+
+[[package]]
+name = "h11"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
+]
+
+[[package]]
+name = "httpcore"
+version = "1.0.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784, upload-time = "2025-04-24T22:06:20.566Z" },
+]
+
+[[package]]
+name = "httpx"
+version = "0.28.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "certifi" },
+    { name = "httpcore" },
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
 ]
 
 [[package]]
 name = "idna"
 version = "3.10"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f1/70/7703c29685631f5a7590aa73f1f1d3fa9a380e654b86af429e0934a32f7d/idna-3.10.tar.gz", hash = "sha256:12f65c9b470abda6dc35cf8e63cc574b1c52b11df2c86030af0ac09b01b13ea9", size = 190490 }
+sdist = { url = "https://files.pythonhosted.org/packages/f1/70/7703c29685631f5a7590aa73f1f1d3fa9a380e654b86af429e0934a32f7d/idna-3.10.tar.gz", hash = "sha256:12f65c9b470abda6dc35cf8e63cc574b1c52b11df2c86030af0ac09b01b13ea9", size = 190490, upload-time = "2024-09-15T18:07:39.745Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/76/c6/c88e154df9c4e1a2a66ccf0005a88dfb2650c1dffb6f5ce603dfbd452ce3/idna-3.10-py3-none-any.whl", hash = "sha256:946d195a0d259cbba61165e88e65941f16e9b36ea6ddb97f00452bae8b1287d3", size = 70442 },
+    { url = "https://files.pythonhosted.org/packages/76/c6/c88e154df9c4e1a2a66ccf0005a88dfb2650c1dffb6f5ce603dfbd452ce3/idna-3.10-py3-none-any.whl", hash = "sha256:946d195a0d259cbba61165e88e65941f16e9b36ea6ddb97f00452bae8b1287d3", size = 70442, upload-time = "2024-09-15T18:07:37.964Z" },
 ]
 
 [[package]]
 name = "iniconfig"
 version = "2.1.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f2/97/ebf4da567aa6827c909642694d71c9fcf53e5b504f2d96afea02718862f3/iniconfig-2.1.0.tar.gz", hash = "sha256:3abbd2e30b36733fee78f9c7f7308f2d0050e88f0087fd25c2645f63c773e1c7", size = 4793 }
+sdist = { url = "https://files.pythonhosted.org/packages/f2/97/ebf4da567aa6827c909642694d71c9fcf53e5b504f2d96afea02718862f3/iniconfig-2.1.0.tar.gz", hash = "sha256:3abbd2e30b36733fee78f9c7f7308f2d0050e88f0087fd25c2645f63c773e1c7", size = 4793, upload-time = "2025-03-19T20:09:59.721Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2c/e1/e6716421ea10d38022b952c159d5161ca1193197fb744506875fbb87ea7b/iniconfig-2.1.0-py3-none-any.whl", hash = "sha256:9deba5723312380e77435581c6bf4935c94cbfab9b1ed33ef8d238ea168eb760", size = 6050 },
+    { url = "https://files.pythonhosted.org/packages/2c/e1/e6716421ea10d38022b952c159d5161ca1193197fb744506875fbb87ea7b/iniconfig-2.1.0-py3-none-any.whl", hash = "sha256:9deba5723312380e77435581c6bf4935c94cbfab9b1ed33ef8d238ea168eb760", size = 6050, upload-time = "2025-03-19T20:10:01.071Z" },
 ]
 
 [[package]]
 name = "isort"
 version = "5.13.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/87/f9/c1eb8635a24e87ade2efce21e3ce8cd6b8630bb685ddc9cdaca1349b2eb5/isort-5.13.2.tar.gz", hash = "sha256:48fdfcb9face5d58a4f6dde2e72a1fb8dcaf8ab26f95ab49fab84c2ddefb0109", size = 175303 }
+sdist = { url = "https://files.pythonhosted.org/packages/87/f9/c1eb8635a24e87ade2efce21e3ce8cd6b8630bb685ddc9cdaca1349b2eb5/isort-5.13.2.tar.gz", hash = "sha256:48fdfcb9face5d58a4f6dde2e72a1fb8dcaf8ab26f95ab49fab84c2ddefb0109", size = 175303, upload-time = "2023-12-13T20:37:26.124Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d1/b3/8def84f539e7d2289a02f0524b944b15d7c75dab7628bedf1c4f0992029c/isort-5.13.2-py3-none-any.whl", hash = "sha256:8ca5e72a8d85860d5a3fa69b8745237f2939afe12dbf656afbcb47fe72d947a6", size = 92310 },
+    { url = "https://files.pythonhosted.org/packages/d1/b3/8def84f539e7d2289a02f0524b944b15d7c75dab7628bedf1c4f0992029c/isort-5.13.2-py3-none-any.whl", hash = "sha256:8ca5e72a8d85860d5a3fa69b8745237f2939afe12dbf656afbcb47fe72d947a6", size = 92310, upload-time = "2023-12-13T20:37:23.244Z" },
+]
+
+[[package]]
+name = "jiter"
+version = "0.12.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/45/9d/e0660989c1370e25848bb4c52d061c71837239738ad937e83edca174c273/jiter-0.12.0.tar.gz", hash = "sha256:64dfcd7d5c168b38d3f9f8bba7fc639edb3418abcc74f22fdbe6b8938293f30b", size = 168294, upload-time = "2025-11-09T20:49:23.302Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/92/c9/5b9f7b4983f1b542c64e84165075335e8a236fa9e2ea03a0c79780062be8/jiter-0.12.0-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:305e061fa82f4680607a775b2e8e0bcb071cd2205ac38e6ef48c8dd5ebe1cf37", size = 314449, upload-time = "2025-11-09T20:47:22.999Z" },
+    { url = "https://files.pythonhosted.org/packages/98/6e/e8efa0e78de00db0aee82c0cf9e8b3f2027efd7f8a71f859d8f4be8e98ef/jiter-0.12.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:5c1860627048e302a528333c9307c818c547f214d8659b0705d2195e1a94b274", size = 319855, upload-time = "2025-11-09T20:47:24.779Z" },
+    { url = "https://files.pythonhosted.org/packages/20/26/894cd88e60b5d58af53bec5c6759d1292bd0b37a8b5f60f07abf7a63ae5f/jiter-0.12.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:df37577a4f8408f7e0ec3205d2a8f87672af8f17008358063a4d6425b6081ce3", size = 350171, upload-time = "2025-11-09T20:47:26.469Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/27/a7b818b9979ac31b3763d25f3653ec3a954044d5e9f5d87f2f247d679fd1/jiter-0.12.0-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:75fdd787356c1c13a4f40b43c2156276ef7a71eb487d98472476476d803fb2cf", size = 365590, upload-time = "2025-11-09T20:47:27.918Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/7e/e46195801a97673a83746170b17984aa8ac4a455746354516d02ca5541b4/jiter-0.12.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:1eb5db8d9c65b112aacf14fcd0faae9913d07a8afea5ed06ccdd12b724e966a1", size = 479462, upload-time = "2025-11-09T20:47:29.654Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/75/f833bfb009ab4bd11b1c9406d333e3b4357709ed0570bb48c7c06d78c7dd/jiter-0.12.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:73c568cc27c473f82480abc15d1301adf333a7ea4f2e813d6a2c7d8b6ba8d0df", size = 378983, upload-time = "2025-11-09T20:47:31.026Z" },
+    { url = "https://files.pythonhosted.org/packages/71/b3/7a69d77943cc837d30165643db753471aff5df39692d598da880a6e51c24/jiter-0.12.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4321e8a3d868919bcb1abb1db550d41f2b5b326f72df29e53b2df8b006eb9403", size = 361328, upload-time = "2025-11-09T20:47:33.286Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/ac/a78f90caf48d65ba70d8c6efc6f23150bc39dc3389d65bbec2a95c7bc628/jiter-0.12.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:0a51bad79f8cc9cac2b4b705039f814049142e0050f30d91695a2d9a6611f126", size = 386740, upload-time = "2025-11-09T20:47:34.703Z" },
+    { url = "https://files.pythonhosted.org/packages/39/b6/5d31c2cc8e1b6a6bcf3c5721e4ca0a3633d1ab4754b09bc7084f6c4f5327/jiter-0.12.0-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:2a67b678f6a5f1dd6c36d642d7db83e456bc8b104788262aaefc11a22339f5a9", size = 520875, upload-time = "2025-11-09T20:47:36.058Z" },
+    { url = "https://files.pythonhosted.org/packages/30/b5/4df540fae4e9f68c54b8dab004bd8c943a752f0b00efd6e7d64aa3850339/jiter-0.12.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:efe1a211fe1fd14762adea941e3cfd6c611a136e28da6c39272dbb7a1bbe6a86", size = 511457, upload-time = "2025-11-09T20:47:37.932Z" },
+    { url = "https://files.pythonhosted.org/packages/07/65/86b74010e450a1a77b2c1aabb91d4a91dd3cd5afce99f34d75fd1ac64b19/jiter-0.12.0-cp312-cp312-win32.whl", hash = "sha256:d779d97c834b4278276ec703dc3fc1735fca50af63eb7262f05bdb4e62203d44", size = 204546, upload-time = "2025-11-09T20:47:40.47Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/c7/6659f537f9562d963488e3e55573498a442503ced01f7e169e96a6110383/jiter-0.12.0-cp312-cp312-win_amd64.whl", hash = "sha256:e8269062060212b373316fe69236096aaf4c49022d267c6736eebd66bbbc60bb", size = 205196, upload-time = "2025-11-09T20:47:41.794Z" },
+    { url = "https://files.pythonhosted.org/packages/21/f4/935304f5169edadfec7f9c01eacbce4c90bb9a82035ac1de1f3bd2d40be6/jiter-0.12.0-cp312-cp312-win_arm64.whl", hash = "sha256:06cb970936c65de926d648af0ed3d21857f026b1cf5525cb2947aa5e01e05789", size = 186100, upload-time = "2025-11-09T20:47:43.007Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/f5/12efb8ada5f5c9edc1d4555fe383c1fb2eac05ac5859258a72d61981d999/jiter-0.12.0-graalpy312-graalpy250_312_native-macosx_10_12_x86_64.whl", hash = "sha256:e8547883d7b96ef2e5fe22b88f8a4c8725a56e7f4abafff20fd5272d634c7ecb", size = 309974, upload-time = "2025-11-09T20:49:17.187Z" },
+    { url = "https://files.pythonhosted.org/packages/85/15/d6eb3b770f6a0d332675141ab3962fd4a7c270ede3515d9f3583e1d28276/jiter-0.12.0-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:89163163c0934854a668ed783a2546a0617f71706a2551a4a0666d91ab365d6b", size = 304233, upload-time = "2025-11-09T20:49:18.734Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/3e/e7e06743294eea2cf02ced6aa0ff2ad237367394e37a0e2b4a1108c67a36/jiter-0.12.0-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d96b264ab7d34bbb2312dedc47ce07cd53f06835eacbc16dde3761f47c3a9e7f", size = 338537, upload-time = "2025-11-09T20:49:20.317Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/9c/6753e6522b8d0ef07d3a3d239426669e984fb0eba15a315cdbc1253904e4/jiter-0.12.0-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c24e864cb30ab82311c6425655b0cdab0a98c5d973b065c66a3f020740c2324c", size = 346110, upload-time = "2025-11-09T20:49:21.817Z" },
 ]
 
 [[package]]
 name = "lxml"
 version = "6.0.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/8f/bd/f9d01fd4132d81c6f43ab01983caea69ec9614b913c290a26738431a015d/lxml-6.0.1.tar.gz", hash = "sha256:2b3a882ebf27dd026df3801a87cf49ff791336e0f94b0fad195db77e01240690", size = 4070214 }
+sdist = { url = "https://files.pythonhosted.org/packages/8f/bd/f9d01fd4132d81c6f43ab01983caea69ec9614b913c290a26738431a015d/lxml-6.0.1.tar.gz", hash = "sha256:2b3a882ebf27dd026df3801a87cf49ff791336e0f94b0fad195db77e01240690", size = 4070214, upload-time = "2025-08-22T10:37:53.525Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b0/a9/82b244c8198fcdf709532e39a1751943a36b3e800b420adc739d751e0299/lxml-6.0.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:c03ac546adaabbe0b8e4a15d9ad815a281afc8d36249c246aecf1aaad7d6f200", size = 8422788 },
-    { url = "https://files.pythonhosted.org/packages/c9/8d/1ed2bc20281b0e7ed3e6c12b0a16e64ae2065d99be075be119ba88486e6d/lxml-6.0.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:33b862c7e3bbeb4ba2c96f3a039f925c640eeba9087a4dc7a572ec0f19d89392", size = 4593547 },
-    { url = "https://files.pythonhosted.org/packages/76/53/d7fd3af95b72a3493bf7fbe842a01e339d8f41567805cecfecd5c71aa5ee/lxml-6.0.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:7a3ec1373f7d3f519de595032d4dcafae396c29407cfd5073f42d267ba32440d", size = 4948101 },
-    { url = "https://files.pythonhosted.org/packages/9d/51/4e57cba4d55273c400fb63aefa2f0d08d15eac021432571a7eeefee67bed/lxml-6.0.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:03b12214fb1608f4cffa181ec3d046c72f7e77c345d06222144744c122ded870", size = 5108090 },
-    { url = "https://files.pythonhosted.org/packages/f6/6e/5f290bc26fcc642bc32942e903e833472271614e24d64ad28aaec09d5dae/lxml-6.0.1-cp312-cp312-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:207ae0d5f0f03b30f95e649a6fa22aa73f5825667fee9c7ec6854d30e19f2ed8", size = 5021791 },
-    { url = "https://files.pythonhosted.org/packages/13/d4/2e7551a86992ece4f9a0f6eebd4fb7e312d30f1e372760e2109e721d4ce6/lxml-6.0.1-cp312-cp312-manylinux_2_26_i686.manylinux_2_28_i686.whl", hash = "sha256:32297b09ed4b17f7b3f448de87a92fb31bb8747496623483788e9f27c98c0f00", size = 5358861 },
-    { url = "https://files.pythonhosted.org/packages/8a/5f/cb49d727fc388bf5fd37247209bab0da11697ddc5e976ccac4826599939e/lxml-6.0.1-cp312-cp312-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:7e18224ea241b657a157c85e9cac82c2b113ec90876e01e1f127312006233756", size = 5652569 },
-    { url = "https://files.pythonhosted.org/packages/ca/b8/66c1ef8c87ad0f958b0a23998851e610607c74849e75e83955d5641272e6/lxml-6.0.1-cp312-cp312-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a07a994d3c46cd4020c1ea566345cf6815af205b1e948213a4f0f1d392182072", size = 5252262 },
-    { url = "https://files.pythonhosted.org/packages/1a/ef/131d3d6b9590e64fdbb932fbc576b81fcc686289da19c7cb796257310e82/lxml-6.0.1-cp312-cp312-manylinux_2_31_armv7l.whl", hash = "sha256:2287fadaa12418a813b05095485c286c47ea58155930cfbd98c590d25770e225", size = 4710309 },
-    { url = "https://files.pythonhosted.org/packages/bc/3f/07f48ae422dce44902309aa7ed386c35310929dc592439c403ec16ef9137/lxml-6.0.1-cp312-cp312-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:b4e597efca032ed99f418bd21314745522ab9fa95af33370dcee5533f7f70136", size = 5265786 },
-    { url = "https://files.pythonhosted.org/packages/11/c7/125315d7b14ab20d9155e8316f7d287a4956098f787c22d47560b74886c4/lxml-6.0.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:9696d491f156226decdd95d9651c6786d43701e49f32bf23715c975539aa2b3b", size = 5062272 },
-    { url = "https://files.pythonhosted.org/packages/8b/c3/51143c3a5fc5168a7c3ee626418468ff20d30f5a59597e7b156c1e61fba8/lxml-6.0.1-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:e4e3cd3585f3c6f87cdea44cda68e692cc42a012f0131d25957ba4ce755241a7", size = 4786955 },
-    { url = "https://files.pythonhosted.org/packages/11/86/73102370a420ec4529647b31c4a8ce8c740c77af3a5fae7a7643212d6f6e/lxml-6.0.1-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:45cbc92f9d22c28cd3b97f8d07fcefa42e569fbd587dfdac76852b16a4924277", size = 5673557 },
-    { url = "https://files.pythonhosted.org/packages/d7/2d/aad90afaec51029aef26ef773b8fd74a9e8706e5e2f46a57acd11a421c02/lxml-6.0.1-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:f8c9bcfd2e12299a442fba94459adf0b0d001dbc68f1594439bfa10ad1ecb74b", size = 5254211 },
-    { url = "https://files.pythonhosted.org/packages/63/01/c9e42c8c2d8b41f4bdefa42ab05448852e439045f112903dd901b8fbea4d/lxml-6.0.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:1e9dc2b9f1586e7cd77753eae81f8d76220eed9b768f337dc83a3f675f2f0cf9", size = 5275817 },
-    { url = "https://files.pythonhosted.org/packages/bc/1f/962ea2696759abe331c3b0e838bb17e92224f39c638c2068bf0d8345e913/lxml-6.0.1-cp312-cp312-win32.whl", hash = "sha256:987ad5c3941c64031f59c226167f55a04d1272e76b241bfafc968bdb778e07fb", size = 3610889 },
-    { url = "https://files.pythonhosted.org/packages/41/e2/22c86a990b51b44442b75c43ecb2f77b8daba8c4ba63696921966eac7022/lxml-6.0.1-cp312-cp312-win_amd64.whl", hash = "sha256:abb05a45394fd76bf4a60c1b7bec0e6d4e8dfc569fc0e0b1f634cd983a006ddc", size = 4010925 },
-    { url = "https://files.pythonhosted.org/packages/b2/21/dc0c73325e5eb94ef9c9d60dbb5dcdcb2e7114901ea9509735614a74e75a/lxml-6.0.1-cp312-cp312-win_arm64.whl", hash = "sha256:c4be29bce35020d8579d60aa0a4e95effd66fcfce31c46ffddf7e5422f73a299", size = 3671922 },
+    { url = "https://files.pythonhosted.org/packages/b0/a9/82b244c8198fcdf709532e39a1751943a36b3e800b420adc739d751e0299/lxml-6.0.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:c03ac546adaabbe0b8e4a15d9ad815a281afc8d36249c246aecf1aaad7d6f200", size = 8422788, upload-time = "2025-08-22T10:32:56.612Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/8d/1ed2bc20281b0e7ed3e6c12b0a16e64ae2065d99be075be119ba88486e6d/lxml-6.0.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:33b862c7e3bbeb4ba2c96f3a039f925c640eeba9087a4dc7a572ec0f19d89392", size = 4593547, upload-time = "2025-08-22T10:32:59.016Z" },
+    { url = "https://files.pythonhosted.org/packages/76/53/d7fd3af95b72a3493bf7fbe842a01e339d8f41567805cecfecd5c71aa5ee/lxml-6.0.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:7a3ec1373f7d3f519de595032d4dcafae396c29407cfd5073f42d267ba32440d", size = 4948101, upload-time = "2025-08-22T10:33:00.765Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/51/4e57cba4d55273c400fb63aefa2f0d08d15eac021432571a7eeefee67bed/lxml-6.0.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:03b12214fb1608f4cffa181ec3d046c72f7e77c345d06222144744c122ded870", size = 5108090, upload-time = "2025-08-22T10:33:03.108Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/6e/5f290bc26fcc642bc32942e903e833472271614e24d64ad28aaec09d5dae/lxml-6.0.1-cp312-cp312-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:207ae0d5f0f03b30f95e649a6fa22aa73f5825667fee9c7ec6854d30e19f2ed8", size = 5021791, upload-time = "2025-08-22T10:33:06.972Z" },
+    { url = "https://files.pythonhosted.org/packages/13/d4/2e7551a86992ece4f9a0f6eebd4fb7e312d30f1e372760e2109e721d4ce6/lxml-6.0.1-cp312-cp312-manylinux_2_26_i686.manylinux_2_28_i686.whl", hash = "sha256:32297b09ed4b17f7b3f448de87a92fb31bb8747496623483788e9f27c98c0f00", size = 5358861, upload-time = "2025-08-22T10:33:08.967Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/5f/cb49d727fc388bf5fd37247209bab0da11697ddc5e976ccac4826599939e/lxml-6.0.1-cp312-cp312-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:7e18224ea241b657a157c85e9cac82c2b113ec90876e01e1f127312006233756", size = 5652569, upload-time = "2025-08-22T10:33:10.815Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/b8/66c1ef8c87ad0f958b0a23998851e610607c74849e75e83955d5641272e6/lxml-6.0.1-cp312-cp312-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a07a994d3c46cd4020c1ea566345cf6815af205b1e948213a4f0f1d392182072", size = 5252262, upload-time = "2025-08-22T10:33:12.673Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/ef/131d3d6b9590e64fdbb932fbc576b81fcc686289da19c7cb796257310e82/lxml-6.0.1-cp312-cp312-manylinux_2_31_armv7l.whl", hash = "sha256:2287fadaa12418a813b05095485c286c47ea58155930cfbd98c590d25770e225", size = 4710309, upload-time = "2025-08-22T10:33:14.952Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/3f/07f48ae422dce44902309aa7ed386c35310929dc592439c403ec16ef9137/lxml-6.0.1-cp312-cp312-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:b4e597efca032ed99f418bd21314745522ab9fa95af33370dcee5533f7f70136", size = 5265786, upload-time = "2025-08-22T10:33:16.721Z" },
+    { url = "https://files.pythonhosted.org/packages/11/c7/125315d7b14ab20d9155e8316f7d287a4956098f787c22d47560b74886c4/lxml-6.0.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:9696d491f156226decdd95d9651c6786d43701e49f32bf23715c975539aa2b3b", size = 5062272, upload-time = "2025-08-22T10:33:18.478Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/c3/51143c3a5fc5168a7c3ee626418468ff20d30f5a59597e7b156c1e61fba8/lxml-6.0.1-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:e4e3cd3585f3c6f87cdea44cda68e692cc42a012f0131d25957ba4ce755241a7", size = 4786955, upload-time = "2025-08-22T10:33:20.34Z" },
+    { url = "https://files.pythonhosted.org/packages/11/86/73102370a420ec4529647b31c4a8ce8c740c77af3a5fae7a7643212d6f6e/lxml-6.0.1-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:45cbc92f9d22c28cd3b97f8d07fcefa42e569fbd587dfdac76852b16a4924277", size = 5673557, upload-time = "2025-08-22T10:33:22.282Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/2d/aad90afaec51029aef26ef773b8fd74a9e8706e5e2f46a57acd11a421c02/lxml-6.0.1-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:f8c9bcfd2e12299a442fba94459adf0b0d001dbc68f1594439bfa10ad1ecb74b", size = 5254211, upload-time = "2025-08-22T10:33:24.15Z" },
+    { url = "https://files.pythonhosted.org/packages/63/01/c9e42c8c2d8b41f4bdefa42ab05448852e439045f112903dd901b8fbea4d/lxml-6.0.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:1e9dc2b9f1586e7cd77753eae81f8d76220eed9b768f337dc83a3f675f2f0cf9", size = 5275817, upload-time = "2025-08-22T10:33:26.007Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/1f/962ea2696759abe331c3b0e838bb17e92224f39c638c2068bf0d8345e913/lxml-6.0.1-cp312-cp312-win32.whl", hash = "sha256:987ad5c3941c64031f59c226167f55a04d1272e76b241bfafc968bdb778e07fb", size = 3610889, upload-time = "2025-08-22T10:33:28.169Z" },
+    { url = "https://files.pythonhosted.org/packages/41/e2/22c86a990b51b44442b75c43ecb2f77b8daba8c4ba63696921966eac7022/lxml-6.0.1-cp312-cp312-win_amd64.whl", hash = "sha256:abb05a45394fd76bf4a60c1b7bec0e6d4e8dfc569fc0e0b1f634cd983a006ddc", size = 4010925, upload-time = "2025-08-22T10:33:29.874Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/21/dc0c73325e5eb94ef9c9d60dbb5dcdcb2e7114901ea9509735614a74e75a/lxml-6.0.1-cp312-cp312-win_arm64.whl", hash = "sha256:c4be29bce35020d8579d60aa0a4e95effd66fcfce31c46ffddf7e5422f73a299", size = 3671922, upload-time = "2025-08-22T10:33:31.535Z" },
 ]
 
 [[package]]
 name = "mccabe"
 version = "0.7.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/e7/ff/0ffefdcac38932a54d2b5eed4e0ba8a408f215002cd178ad1df0f2806ff8/mccabe-0.7.0.tar.gz", hash = "sha256:348e0240c33b60bbdf4e523192ef919f28cb2c3d7d5c7794f74009290f236325", size = 9658 }
+sdist = { url = "https://files.pythonhosted.org/packages/e7/ff/0ffefdcac38932a54d2b5eed4e0ba8a408f215002cd178ad1df0f2806ff8/mccabe-0.7.0.tar.gz", hash = "sha256:348e0240c33b60bbdf4e523192ef919f28cb2c3d7d5c7794f74009290f236325", size = 9658, upload-time = "2022-01-24T01:14:51.113Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/27/1a/1f68f9ba0c207934b35b86a8ca3aad8395a3d6dd7921c0686e23853ff5a9/mccabe-0.7.0-py2.py3-none-any.whl", hash = "sha256:6c2d30ab6be0e4a46919781807b4f0d834ebdd6c6e3dca0bda5a15f863427b6e", size = 7350 },
+    { url = "https://files.pythonhosted.org/packages/27/1a/1f68f9ba0c207934b35b86a8ca3aad8395a3d6dd7921c0686e23853ff5a9/mccabe-0.7.0-py2.py3-none-any.whl", hash = "sha256:6c2d30ab6be0e4a46919781807b4f0d834ebdd6c6e3dca0bda5a15f863427b6e", size = 7350, upload-time = "2022-01-24T01:14:49.62Z" },
 ]
 
 [[package]]
@@ -218,33 +311,33 @@ dependencies = [
     { name = "pathspec" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c0/77/8f0d0001ffad290cef2f7f216f96c814866248a0b92a722365ed54648e7e/mypy-1.18.2.tar.gz", hash = "sha256:06a398102a5f203d7477b2923dda3634c36727fa5c237d8f859ef90c42a9924b", size = 3448846 }
+sdist = { url = "https://files.pythonhosted.org/packages/c0/77/8f0d0001ffad290cef2f7f216f96c814866248a0b92a722365ed54648e7e/mypy-1.18.2.tar.gz", hash = "sha256:06a398102a5f203d7477b2923dda3634c36727fa5c237d8f859ef90c42a9924b", size = 3448846, upload-time = "2025-09-19T00:11:10.519Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/07/06/dfdd2bc60c66611dd8335f463818514733bc763e4760dee289dcc33df709/mypy-1.18.2-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:33eca32dd124b29400c31d7cf784e795b050ace0e1f91b8dc035672725617e34", size = 12908273 },
-    { url = "https://files.pythonhosted.org/packages/81/14/6a9de6d13a122d5608e1a04130724caf9170333ac5a924e10f670687d3eb/mypy-1.18.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:a3c47adf30d65e89b2dcd2fa32f3aeb5e94ca970d2c15fcb25e297871c8e4764", size = 11920910 },
-    { url = "https://files.pythonhosted.org/packages/5f/a9/b29de53e42f18e8cc547e38daa9dfa132ffdc64f7250e353f5c8cdd44bee/mypy-1.18.2-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5d6c838e831a062f5f29d11c9057c6009f60cb294fea33a98422688181fe2893", size = 12465585 },
-    { url = "https://files.pythonhosted.org/packages/77/ae/6c3d2c7c61ff21f2bee938c917616c92ebf852f015fb55917fd6e2811db2/mypy-1.18.2-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:01199871b6110a2ce984bde85acd481232d17413868c9807e95c1b0739a58914", size = 13348562 },
-    { url = "https://files.pythonhosted.org/packages/4d/31/aec68ab3b4aebdf8f36d191b0685d99faa899ab990753ca0fee60fb99511/mypy-1.18.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:a2afc0fa0b0e91b4599ddfe0f91e2c26c2b5a5ab263737e998d6817874c5f7c8", size = 13533296 },
-    { url = "https://files.pythonhosted.org/packages/9f/83/abcb3ad9478fca3ebeb6a5358bb0b22c95ea42b43b7789c7fb1297ca44f4/mypy-1.18.2-cp312-cp312-win_amd64.whl", hash = "sha256:d8068d0afe682c7c4897c0f7ce84ea77f6de953262b12d07038f4d296d547074", size = 9828828 },
-    { url = "https://files.pythonhosted.org/packages/87/e3/be76d87158ebafa0309946c4a73831974d4d6ab4f4ef40c3b53a385a66fd/mypy-1.18.2-py3-none-any.whl", hash = "sha256:22a1748707dd62b58d2ae53562ffc4d7f8bcc727e8ac7cbc69c053ddc874d47e", size = 2352367 },
+    { url = "https://files.pythonhosted.org/packages/07/06/dfdd2bc60c66611dd8335f463818514733bc763e4760dee289dcc33df709/mypy-1.18.2-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:33eca32dd124b29400c31d7cf784e795b050ace0e1f91b8dc035672725617e34", size = 12908273, upload-time = "2025-09-19T00:10:58.321Z" },
+    { url = "https://files.pythonhosted.org/packages/81/14/6a9de6d13a122d5608e1a04130724caf9170333ac5a924e10f670687d3eb/mypy-1.18.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:a3c47adf30d65e89b2dcd2fa32f3aeb5e94ca970d2c15fcb25e297871c8e4764", size = 11920910, upload-time = "2025-09-19T00:10:20.043Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/a9/b29de53e42f18e8cc547e38daa9dfa132ffdc64f7250e353f5c8cdd44bee/mypy-1.18.2-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5d6c838e831a062f5f29d11c9057c6009f60cb294fea33a98422688181fe2893", size = 12465585, upload-time = "2025-09-19T00:10:33.005Z" },
+    { url = "https://files.pythonhosted.org/packages/77/ae/6c3d2c7c61ff21f2bee938c917616c92ebf852f015fb55917fd6e2811db2/mypy-1.18.2-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:01199871b6110a2ce984bde85acd481232d17413868c9807e95c1b0739a58914", size = 13348562, upload-time = "2025-09-19T00:10:11.51Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/31/aec68ab3b4aebdf8f36d191b0685d99faa899ab990753ca0fee60fb99511/mypy-1.18.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:a2afc0fa0b0e91b4599ddfe0f91e2c26c2b5a5ab263737e998d6817874c5f7c8", size = 13533296, upload-time = "2025-09-19T00:10:06.568Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/83/abcb3ad9478fca3ebeb6a5358bb0b22c95ea42b43b7789c7fb1297ca44f4/mypy-1.18.2-cp312-cp312-win_amd64.whl", hash = "sha256:d8068d0afe682c7c4897c0f7ce84ea77f6de953262b12d07038f4d296d547074", size = 9828828, upload-time = "2025-09-19T00:10:28.203Z" },
+    { url = "https://files.pythonhosted.org/packages/87/e3/be76d87158ebafa0309946c4a73831974d4d6ab4f4ef40c3b53a385a66fd/mypy-1.18.2-py3-none-any.whl", hash = "sha256:22a1748707dd62b58d2ae53562ffc4d7f8bcc727e8ac7cbc69c053ddc874d47e", size = 2352367, upload-time = "2025-09-19T00:10:15.489Z" },
 ]
 
 [[package]]
 name = "mypy-extensions"
 version = "1.1.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/a2/6e/371856a3fb9d31ca8dac321cda606860fa4548858c0cc45d9d1d4ca2628b/mypy_extensions-1.1.0.tar.gz", hash = "sha256:52e68efc3284861e772bbcd66823fde5ae21fd2fdb51c62a211403730b916558", size = 6343 }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/6e/371856a3fb9d31ca8dac321cda606860fa4548858c0cc45d9d1d4ca2628b/mypy_extensions-1.1.0.tar.gz", hash = "sha256:52e68efc3284861e772bbcd66823fde5ae21fd2fdb51c62a211403730b916558", size = 6343, upload-time = "2025-04-22T14:54:24.164Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/79/7b/2c79738432f5c924bef5071f933bcc9efd0473bac3b4aa584a6f7c1c8df8/mypy_extensions-1.1.0-py3-none-any.whl", hash = "sha256:1be4cccdb0f2482337c4743e60421de3a356cd97508abadd57d47403e94f5505", size = 4963 },
+    { url = "https://files.pythonhosted.org/packages/79/7b/2c79738432f5c924bef5071f933bcc9efd0473bac3b4aa584a6f7c1c8df8/mypy_extensions-1.1.0-py3-none-any.whl", hash = "sha256:1be4cccdb0f2482337c4743e60421de3a356cd97508abadd57d47403e94f5505", size = 4963, upload-time = "2025-04-22T14:54:22.983Z" },
 ]
 
 [[package]]
 name = "narwhals"
 version = "2.5.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/7b/b8/3cb005704866f1cc19e8d6b15d0467255821ba12d82f20ea15912672e54c/narwhals-2.5.0.tar.gz", hash = "sha256:8ae0b6f39597f14c0dc52afc98949d6f8be89b5af402d2d98101d2f7d3561418", size = 558573 }
+sdist = { url = "https://files.pythonhosted.org/packages/7b/b8/3cb005704866f1cc19e8d6b15d0467255821ba12d82f20ea15912672e54c/narwhals-2.5.0.tar.gz", hash = "sha256:8ae0b6f39597f14c0dc52afc98949d6f8be89b5af402d2d98101d2f7d3561418", size = 558573, upload-time = "2025-09-12T10:04:24.436Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f8/5a/22741c5c0e5f6e8050242bfc2052ba68bc94b1735ed5bca35404d136d6ec/narwhals-2.5.0-py3-none-any.whl", hash = "sha256:7e213f9ca7db3f8bf6f7eff35eaee6a1cf80902997e1b78d49b7755775d8f423", size = 407296 },
+    { url = "https://files.pythonhosted.org/packages/f8/5a/22741c5c0e5f6e8050242bfc2052ba68bc94b1735ed5bca35404d136d6ec/narwhals-2.5.0-py3-none-any.whl", hash = "sha256:7e213f9ca7db3f8bf6f7eff35eaee6a1cf80902997e1b78d49b7755775d8f423", size = 407296, upload-time = "2025-09-12T10:04:22.524Z" },
 ]
 
 [[package]]
@@ -254,28 +347,47 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pytz" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/50/69/4862fabc082f2447131aada5c91736155349d77ebf443af7f59553b7b789/neo4j-5.28.2.tar.gz", hash = "sha256:7d38e27e4f987a45cc9052500c6ee27325cb23dae6509037fe31dd7ddaed70c7", size = 231874 }
+sdist = { url = "https://files.pythonhosted.org/packages/50/69/4862fabc082f2447131aada5c91736155349d77ebf443af7f59553b7b789/neo4j-5.28.2.tar.gz", hash = "sha256:7d38e27e4f987a45cc9052500c6ee27325cb23dae6509037fe31dd7ddaed70c7", size = 231874, upload-time = "2025-07-30T06:04:34.669Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/04/00/1f74089c06aec1fac9390e2300a6a6b2381e0dac281783d64ccca9d681fd/neo4j-5.28.2-py3-none-any.whl", hash = "sha256:5c53b5c3eee6dee7e920c9724391aa38d7135a651e71b766da00533b92a91a94", size = 313156 },
+    { url = "https://files.pythonhosted.org/packages/04/00/1f74089c06aec1fac9390e2300a6a6b2381e0dac281783d64ccca9d681fd/neo4j-5.28.2-py3-none-any.whl", hash = "sha256:5c53b5c3eee6dee7e920c9724391aa38d7135a651e71b766da00533b92a91a94", size = 313156, upload-time = "2025-07-30T06:04:31.438Z" },
 ]
 
 [[package]]
 name = "numpy"
 version = "2.3.3"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/d0/19/95b3d357407220ed24c139018d2518fab0a61a948e68286a25f1a4d049ff/numpy-2.3.3.tar.gz", hash = "sha256:ddc7c39727ba62b80dfdbedf400d1c10ddfa8eefbd7ec8dcb118be8b56d31029", size = 20576648 }
+sdist = { url = "https://files.pythonhosted.org/packages/d0/19/95b3d357407220ed24c139018d2518fab0a61a948e68286a25f1a4d049ff/numpy-2.3.3.tar.gz", hash = "sha256:ddc7c39727ba62b80dfdbedf400d1c10ddfa8eefbd7ec8dcb118be8b56d31029", size = 20576648, upload-time = "2025-09-09T16:54:12.543Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/51/5d/bb7fc075b762c96329147799e1bcc9176ab07ca6375ea976c475482ad5b3/numpy-2.3.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:cfdd09f9c84a1a934cde1eec2267f0a43a7cd44b2cca4ff95b7c0d14d144b0bf", size = 20957014 },
-    { url = "https://files.pythonhosted.org/packages/6b/0e/c6211bb92af26517acd52125a237a92afe9c3124c6a68d3b9f81b62a0568/numpy-2.3.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:cb32e3cf0f762aee47ad1ddc6672988f7f27045b0783c887190545baba73aa25", size = 14185220 },
-    { url = "https://files.pythonhosted.org/packages/22/f2/07bb754eb2ede9073f4054f7c0286b0d9d2e23982e090a80d478b26d35ca/numpy-2.3.3-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:396b254daeb0a57b1fe0ecb5e3cff6fa79a380fa97c8f7781a6d08cd429418fe", size = 5113918 },
-    { url = "https://files.pythonhosted.org/packages/81/0a/afa51697e9fb74642f231ea36aca80fa17c8fb89f7a82abd5174023c3960/numpy-2.3.3-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:067e3d7159a5d8f8a0b46ee11148fc35ca9b21f61e3c49fbd0a027450e65a33b", size = 6647922 },
-    { url = "https://files.pythonhosted.org/packages/5d/f5/122d9cdb3f51c520d150fef6e87df9279e33d19a9611a87c0d2cf78a89f4/numpy-2.3.3-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1c02d0629d25d426585fb2e45a66154081b9fa677bc92a881ff1d216bc9919a8", size = 14281991 },
-    { url = "https://files.pythonhosted.org/packages/51/64/7de3c91e821a2debf77c92962ea3fe6ac2bc45d0778c1cbe15d4fce2fd94/numpy-2.3.3-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d9192da52b9745f7f0766531dcfa978b7763916f158bb63bdb8a1eca0068ab20", size = 16641643 },
-    { url = "https://files.pythonhosted.org/packages/30/e4/961a5fa681502cd0d68907818b69f67542695b74e3ceaa513918103b7e80/numpy-2.3.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:cd7de500a5b66319db419dc3c345244404a164beae0d0937283b907d8152e6ea", size = 16056787 },
-    { url = "https://files.pythonhosted.org/packages/99/26/92c912b966e47fbbdf2ad556cb17e3a3088e2e1292b9833be1dfa5361a1a/numpy-2.3.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:93d4962d8f82af58f0b2eb85daaf1b3ca23fe0a85d0be8f1f2b7bb46034e56d7", size = 18579598 },
-    { url = "https://files.pythonhosted.org/packages/17/b6/fc8f82cb3520768718834f310c37d96380d9dc61bfdaf05fe5c0b7653e01/numpy-2.3.3-cp312-cp312-win32.whl", hash = "sha256:5534ed6b92f9b7dca6c0a19d6df12d41c68b991cef051d108f6dbff3babc4ebf", size = 6320800 },
-    { url = "https://files.pythonhosted.org/packages/32/ee/de999f2625b80d043d6d2d628c07d0d5555a677a3cf78fdf868d409b8766/numpy-2.3.3-cp312-cp312-win_amd64.whl", hash = "sha256:497d7cad08e7092dba36e3d296fe4c97708c93daf26643a1ae4b03f6294d30eb", size = 12786615 },
-    { url = "https://files.pythonhosted.org/packages/49/6e/b479032f8a43559c383acb20816644f5f91c88f633d9271ee84f3b3a996c/numpy-2.3.3-cp312-cp312-win_arm64.whl", hash = "sha256:ca0309a18d4dfea6fc6262a66d06c26cfe4640c3926ceec90e57791a82b6eee5", size = 10195936 },
+    { url = "https://files.pythonhosted.org/packages/51/5d/bb7fc075b762c96329147799e1bcc9176ab07ca6375ea976c475482ad5b3/numpy-2.3.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:cfdd09f9c84a1a934cde1eec2267f0a43a7cd44b2cca4ff95b7c0d14d144b0bf", size = 20957014, upload-time = "2025-09-09T15:56:29.966Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/0e/c6211bb92af26517acd52125a237a92afe9c3124c6a68d3b9f81b62a0568/numpy-2.3.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:cb32e3cf0f762aee47ad1ddc6672988f7f27045b0783c887190545baba73aa25", size = 14185220, upload-time = "2025-09-09T15:56:32.175Z" },
+    { url = "https://files.pythonhosted.org/packages/22/f2/07bb754eb2ede9073f4054f7c0286b0d9d2e23982e090a80d478b26d35ca/numpy-2.3.3-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:396b254daeb0a57b1fe0ecb5e3cff6fa79a380fa97c8f7781a6d08cd429418fe", size = 5113918, upload-time = "2025-09-09T15:56:34.175Z" },
+    { url = "https://files.pythonhosted.org/packages/81/0a/afa51697e9fb74642f231ea36aca80fa17c8fb89f7a82abd5174023c3960/numpy-2.3.3-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:067e3d7159a5d8f8a0b46ee11148fc35ca9b21f61e3c49fbd0a027450e65a33b", size = 6647922, upload-time = "2025-09-09T15:56:36.149Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/f5/122d9cdb3f51c520d150fef6e87df9279e33d19a9611a87c0d2cf78a89f4/numpy-2.3.3-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1c02d0629d25d426585fb2e45a66154081b9fa677bc92a881ff1d216bc9919a8", size = 14281991, upload-time = "2025-09-09T15:56:40.548Z" },
+    { url = "https://files.pythonhosted.org/packages/51/64/7de3c91e821a2debf77c92962ea3fe6ac2bc45d0778c1cbe15d4fce2fd94/numpy-2.3.3-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d9192da52b9745f7f0766531dcfa978b7763916f158bb63bdb8a1eca0068ab20", size = 16641643, upload-time = "2025-09-09T15:56:43.343Z" },
+    { url = "https://files.pythonhosted.org/packages/30/e4/961a5fa681502cd0d68907818b69f67542695b74e3ceaa513918103b7e80/numpy-2.3.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:cd7de500a5b66319db419dc3c345244404a164beae0d0937283b907d8152e6ea", size = 16056787, upload-time = "2025-09-09T15:56:46.141Z" },
+    { url = "https://files.pythonhosted.org/packages/99/26/92c912b966e47fbbdf2ad556cb17e3a3088e2e1292b9833be1dfa5361a1a/numpy-2.3.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:93d4962d8f82af58f0b2eb85daaf1b3ca23fe0a85d0be8f1f2b7bb46034e56d7", size = 18579598, upload-time = "2025-09-09T15:56:49.844Z" },
+    { url = "https://files.pythonhosted.org/packages/17/b6/fc8f82cb3520768718834f310c37d96380d9dc61bfdaf05fe5c0b7653e01/numpy-2.3.3-cp312-cp312-win32.whl", hash = "sha256:5534ed6b92f9b7dca6c0a19d6df12d41c68b991cef051d108f6dbff3babc4ebf", size = 6320800, upload-time = "2025-09-09T15:56:52.499Z" },
+    { url = "https://files.pythonhosted.org/packages/32/ee/de999f2625b80d043d6d2d628c07d0d5555a677a3cf78fdf868d409b8766/numpy-2.3.3-cp312-cp312-win_amd64.whl", hash = "sha256:497d7cad08e7092dba36e3d296fe4c97708c93daf26643a1ae4b03f6294d30eb", size = 12786615, upload-time = "2025-09-09T15:56:54.422Z" },
+    { url = "https://files.pythonhosted.org/packages/49/6e/b479032f8a43559c383acb20816644f5f91c88f633d9271ee84f3b3a996c/numpy-2.3.3-cp312-cp312-win_arm64.whl", hash = "sha256:ca0309a18d4dfea6fc6262a66d06c26cfe4640c3926ceec90e57791a82b6eee5", size = 10195936, upload-time = "2025-09-09T15:56:56.541Z" },
+]
+
+[[package]]
+name = "openai"
+version = "2.9.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "distro" },
+    { name = "httpx" },
+    { name = "jiter" },
+    { name = "pydantic" },
+    { name = "sniffio" },
+    { name = "tqdm" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/09/48/516290f38745cc1e72856f50e8afed4a7f9ac396a5a18f39e892ab89dfc2/openai-2.9.0.tar.gz", hash = "sha256:b52ec65727fc8f1eed2fbc86c8eac0998900c7ef63aa2eb5c24b69717c56fa5f", size = 608202, upload-time = "2025-12-04T18:15:09.01Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/59/fd/ae2da789cd923dd033c99b8d544071a827c92046b150db01cfa5cea5b3fd/openai-2.9.0-py3-none-any.whl", hash = "sha256:0d168a490fbb45630ad508a6f3022013c155a68fd708069b6a1a01a5e8f0ffad", size = 1030836, upload-time = "2025-12-04T18:15:07.063Z" },
 ]
 
 [[package]]
@@ -290,16 +402,16 @@ dependencies = [
     { name = "requests-file" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d9/23/e76575618af74b3572b6791b6e1cc403832af9cb2d6c6961a0749b37bf84/OpenDartReader-0.2.3-py3-none-any.whl", hash = "sha256:710c01969e5b01dc1b7bc78a9f5f13cad11623cdb2f6ed45110f6cd40a111ecc", size = 27544 },
+    { url = "https://files.pythonhosted.org/packages/d9/23/e76575618af74b3572b6791b6e1cc403832af9cb2d6c6961a0749b37bf84/OpenDartReader-0.2.3-py3-none-any.whl", hash = "sha256:710c01969e5b01dc1b7bc78a9f5f13cad11623cdb2f6ed45110f6cd40a111ecc", size = 27544, upload-time = "2023-03-15T07:17:25.548Z" },
 ]
 
 [[package]]
 name = "packaging"
 version = "25.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/a1/d4/1fc4078c65507b51b96ca8f8c3ba19e6a61c8253c72794544580a7b6c24d/packaging-25.0.tar.gz", hash = "sha256:d443872c98d677bf60f6a1f2f8c1cb748e8fe762d2bf9d3148b5599295b0fc4f", size = 165727 }
+sdist = { url = "https://files.pythonhosted.org/packages/a1/d4/1fc4078c65507b51b96ca8f8c3ba19e6a61c8253c72794544580a7b6c24d/packaging-25.0.tar.gz", hash = "sha256:d443872c98d677bf60f6a1f2f8c1cb748e8fe762d2bf9d3148b5599295b0fc4f", size = 165727, upload-time = "2025-04-19T11:48:59.673Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/20/12/38679034af332785aac8774540895e234f4d07f7545804097de4b666afd8/packaging-25.0-py3-none-any.whl", hash = "sha256:29572ef2b1f17581046b3a2227d5c611fb25ec70ca1ba8554b24b0e69331a484", size = 66469 },
+    { url = "https://files.pythonhosted.org/packages/20/12/38679034af332785aac8774540895e234f4d07f7545804097de4b666afd8/packaging-25.0-py3-none-any.whl", hash = "sha256:29572ef2b1f17581046b3a2227d5c611fb25ec70ca1ba8554b24b0e69331a484", size = 66469, upload-time = "2025-04-19T11:48:57.875Z" },
 ]
 
 [[package]]
@@ -312,33 +424,33 @@ dependencies = [
     { name = "pytz" },
     { name = "tzdata" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/79/8e/0e90233ac205ad182bd6b422532695d2b9414944a280488105d598c70023/pandas-2.3.2.tar.gz", hash = "sha256:ab7b58f8f82706890924ccdfb5f48002b83d2b5a3845976a9fb705d36c34dcdb", size = 4488684 }
+sdist = { url = "https://files.pythonhosted.org/packages/79/8e/0e90233ac205ad182bd6b422532695d2b9414944a280488105d598c70023/pandas-2.3.2.tar.gz", hash = "sha256:ab7b58f8f82706890924ccdfb5f48002b83d2b5a3845976a9fb705d36c34dcdb", size = 4488684, upload-time = "2025-08-21T10:28:29.257Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ec/db/614c20fb7a85a14828edd23f1c02db58a30abf3ce76f38806155d160313c/pandas-2.3.2-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:3fbb977f802156e7a3f829e9d1d5398f6192375a3e2d1a9ee0803e35fe70a2b9", size = 11587652 },
-    { url = "https://files.pythonhosted.org/packages/99/b0/756e52f6582cade5e746f19bad0517ff27ba9c73404607c0306585c201b3/pandas-2.3.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:1b9b52693123dd234b7c985c68b709b0b009f4521000d0525f2b95c22f15944b", size = 10717686 },
-    { url = "https://files.pythonhosted.org/packages/37/4c/dd5ccc1e357abfeee8353123282de17997f90ff67855f86154e5a13b81e5/pandas-2.3.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0bd281310d4f412733f319a5bc552f86d62cddc5f51d2e392c8787335c994175", size = 11278722 },
-    { url = "https://files.pythonhosted.org/packages/d3/a4/f7edcfa47e0a88cda0be8b068a5bae710bf264f867edfdf7b71584ace362/pandas-2.3.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:96d31a6b4354e3b9b8a2c848af75d31da390657e3ac6f30c05c82068b9ed79b9", size = 11987803 },
-    { url = "https://files.pythonhosted.org/packages/f6/61/1bce4129f93ab66f1c68b7ed1c12bac6a70b1b56c5dab359c6bbcd480b52/pandas-2.3.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:df4df0b9d02bb873a106971bb85d448378ef14b86ba96f035f50bbd3688456b4", size = 12766345 },
-    { url = "https://files.pythonhosted.org/packages/8e/46/80d53de70fee835531da3a1dae827a1e76e77a43ad22a8cd0f8142b61587/pandas-2.3.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:213a5adf93d020b74327cb2c1b842884dbdd37f895f42dcc2f09d451d949f811", size = 13439314 },
-    { url = "https://files.pythonhosted.org/packages/28/30/8114832daff7489f179971dbc1d854109b7f4365a546e3ea75b6516cea95/pandas-2.3.2-cp312-cp312-win_amd64.whl", hash = "sha256:8c13b81a9347eb8c7548f53fd9a4f08d4dfe996836543f805c987bafa03317ae", size = 10983326 },
+    { url = "https://files.pythonhosted.org/packages/ec/db/614c20fb7a85a14828edd23f1c02db58a30abf3ce76f38806155d160313c/pandas-2.3.2-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:3fbb977f802156e7a3f829e9d1d5398f6192375a3e2d1a9ee0803e35fe70a2b9", size = 11587652, upload-time = "2025-08-21T10:27:15.888Z" },
+    { url = "https://files.pythonhosted.org/packages/99/b0/756e52f6582cade5e746f19bad0517ff27ba9c73404607c0306585c201b3/pandas-2.3.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:1b9b52693123dd234b7c985c68b709b0b009f4521000d0525f2b95c22f15944b", size = 10717686, upload-time = "2025-08-21T10:27:18.486Z" },
+    { url = "https://files.pythonhosted.org/packages/37/4c/dd5ccc1e357abfeee8353123282de17997f90ff67855f86154e5a13b81e5/pandas-2.3.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0bd281310d4f412733f319a5bc552f86d62cddc5f51d2e392c8787335c994175", size = 11278722, upload-time = "2025-08-21T10:27:21.149Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/a4/f7edcfa47e0a88cda0be8b068a5bae710bf264f867edfdf7b71584ace362/pandas-2.3.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:96d31a6b4354e3b9b8a2c848af75d31da390657e3ac6f30c05c82068b9ed79b9", size = 11987803, upload-time = "2025-08-21T10:27:23.767Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/61/1bce4129f93ab66f1c68b7ed1c12bac6a70b1b56c5dab359c6bbcd480b52/pandas-2.3.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:df4df0b9d02bb873a106971bb85d448378ef14b86ba96f035f50bbd3688456b4", size = 12766345, upload-time = "2025-08-21T10:27:26.6Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/46/80d53de70fee835531da3a1dae827a1e76e77a43ad22a8cd0f8142b61587/pandas-2.3.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:213a5adf93d020b74327cb2c1b842884dbdd37f895f42dcc2f09d451d949f811", size = 13439314, upload-time = "2025-08-21T10:27:29.213Z" },
+    { url = "https://files.pythonhosted.org/packages/28/30/8114832daff7489f179971dbc1d854109b7f4365a546e3ea75b6516cea95/pandas-2.3.2-cp312-cp312-win_amd64.whl", hash = "sha256:8c13b81a9347eb8c7548f53fd9a4f08d4dfe996836543f805c987bafa03317ae", size = 10983326, upload-time = "2025-08-21T10:27:31.901Z" },
 ]
 
 [[package]]
 name = "pathspec"
 version = "0.12.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ca/bc/f35b8446f4531a7cb215605d100cd88b7ac6f44ab3fc94870c120ab3adbf/pathspec-0.12.1.tar.gz", hash = "sha256:a482d51503a1ab33b1c67a6c3813a26953dbdc71c31dacaef9a838c4e29f5712", size = 51043 }
+sdist = { url = "https://files.pythonhosted.org/packages/ca/bc/f35b8446f4531a7cb215605d100cd88b7ac6f44ab3fc94870c120ab3adbf/pathspec-0.12.1.tar.gz", hash = "sha256:a482d51503a1ab33b1c67a6c3813a26953dbdc71c31dacaef9a838c4e29f5712", size = 51043, upload-time = "2023-12-10T22:30:45Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/cc/20/ff623b09d963f88bfde16306a54e12ee5ea43e9b597108672ff3a408aad6/pathspec-0.12.1-py3-none-any.whl", hash = "sha256:a0d503e138a4c123b27490a4f7beda6a01c6f288df0e4a8b79c7eb0dc7b4cc08", size = 31191 },
+    { url = "https://files.pythonhosted.org/packages/cc/20/ff623b09d963f88bfde16306a54e12ee5ea43e9b597108672ff3a408aad6/pathspec-0.12.1-py3-none-any.whl", hash = "sha256:a0d503e138a4c123b27490a4f7beda6a01c6f288df0e4a8b79c7eb0dc7b4cc08", size = 31191, upload-time = "2023-12-10T22:30:43.14Z" },
 ]
 
 [[package]]
 name = "platformdirs"
 version = "4.5.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/61/33/9611380c2bdb1225fdef633e2a9610622310fed35ab11dac9620972ee088/platformdirs-4.5.0.tar.gz", hash = "sha256:70ddccdd7c99fc5942e9fc25636a8b34d04c24b335100223152c2803e4063312", size = 21632 }
+sdist = { url = "https://files.pythonhosted.org/packages/61/33/9611380c2bdb1225fdef633e2a9610622310fed35ab11dac9620972ee088/platformdirs-4.5.0.tar.gz", hash = "sha256:70ddccdd7c99fc5942e9fc25636a8b34d04c24b335100223152c2803e4063312", size = 21632, upload-time = "2025-10-08T17:44:48.791Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/73/cb/ac7874b3e5d58441674fb70742e6c374b28b0c7cb988d37d991cde47166c/platformdirs-4.5.0-py3-none-any.whl", hash = "sha256:e578a81bb873cbb89a41fcc904c7ef523cc18284b7e3b3ccf06aca1403b7ebd3", size = 18651 },
+    { url = "https://files.pythonhosted.org/packages/73/cb/ac7874b3e5d58441674fb70742e6c374b28b0c7cb988d37d991cde47166c/platformdirs-4.5.0-py3-none-any.whl", hash = "sha256:e578a81bb873cbb89a41fcc904c7ef523cc18284b7e3b3ccf06aca1403b7ebd3", size = 18651, upload-time = "2025-10-08T17:44:47.223Z" },
 ]
 
 [[package]]
@@ -349,36 +461,80 @@ dependencies = [
     { name = "narwhals" },
     { name = "packaging" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a0/64/850de5076f4436410e1ce4f6a69f4313ef6215dfea155f3f6559335cad29/plotly-6.3.0.tar.gz", hash = "sha256:8840a184d18ccae0f9189c2b9a2943923fd5cae7717b723f36eef78f444e5a73", size = 6923926 }
+sdist = { url = "https://files.pythonhosted.org/packages/a0/64/850de5076f4436410e1ce4f6a69f4313ef6215dfea155f3f6559335cad29/plotly-6.3.0.tar.gz", hash = "sha256:8840a184d18ccae0f9189c2b9a2943923fd5cae7717b723f36eef78f444e5a73", size = 6923926, upload-time = "2025-08-12T20:22:14.127Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/95/a9/12e2dc726ba1ba775a2c6922d5d5b4488ad60bdab0888c337c194c8e6de8/plotly-6.3.0-py3-none-any.whl", hash = "sha256:7ad806edce9d3cdd882eaebaf97c0c9e252043ed1ed3d382c3e3520ec07806d4", size = 9791257 },
+    { url = "https://files.pythonhosted.org/packages/95/a9/12e2dc726ba1ba775a2c6922d5d5b4488ad60bdab0888c337c194c8e6de8/plotly-6.3.0-py3-none-any.whl", hash = "sha256:7ad806edce9d3cdd882eaebaf97c0c9e252043ed1ed3d382c3e3520ec07806d4", size = 9791257, upload-time = "2025-08-12T20:22:09.205Z" },
 ]
 
 [[package]]
 name = "pluggy"
 version = "1.6.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412 }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538 },
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
 ]
 
 [[package]]
 name = "pycodestyle"
 version = "2.11.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/34/8f/fa09ae2acc737b9507b5734a9aec9a2b35fa73409982f57db1b42f8c3c65/pycodestyle-2.11.1.tar.gz", hash = "sha256:41ba0e7afc9752dfb53ced5489e89f8186be00e599e712660695b7a75ff2663f", size = 38974 }
+sdist = { url = "https://files.pythonhosted.org/packages/34/8f/fa09ae2acc737b9507b5734a9aec9a2b35fa73409982f57db1b42f8c3c65/pycodestyle-2.11.1.tar.gz", hash = "sha256:41ba0e7afc9752dfb53ced5489e89f8186be00e599e712660695b7a75ff2663f", size = 38974, upload-time = "2023-10-12T23:39:39.762Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b1/90/a998c550d0ddd07e38605bb5c455d00fcc177a800ff9cc3dafdcb3dd7b56/pycodestyle-2.11.1-py2.py3-none-any.whl", hash = "sha256:44fe31000b2d866f2e41841b18528a505fbd7fef9017b04eff4e2648a0fadc67", size = 31132 },
+    { url = "https://files.pythonhosted.org/packages/b1/90/a998c550d0ddd07e38605bb5c455d00fcc177a800ff9cc3dafdcb3dd7b56/pycodestyle-2.11.1-py2.py3-none-any.whl", hash = "sha256:44fe31000b2d866f2e41841b18528a505fbd7fef9017b04eff4e2648a0fadc67", size = 31132, upload-time = "2023-10-12T23:39:38.242Z" },
+]
+
+[[package]]
+name = "pydantic"
+version = "2.12.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-types" },
+    { name = "pydantic-core" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/69/44/36f1a6e523abc58ae5f928898e4aca2e0ea509b5aa6f6f392a5d882be928/pydantic-2.12.5.tar.gz", hash = "sha256:4d351024c75c0f085a9febbb665ce8c0c6ec5d30e903bdb6394b7ede26aebb49", size = 821591, upload-time = "2025-11-26T15:11:46.471Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5a/87/b70ad306ebb6f9b585f114d0ac2137d792b48be34d732d60e597c2f8465a/pydantic-2.12.5-py3-none-any.whl", hash = "sha256:e561593fccf61e8a20fc46dfc2dfe075b8be7d0188df33f221ad1f0139180f9d", size = 463580, upload-time = "2025-11-26T15:11:44.605Z" },
+]
+
+[[package]]
+name = "pydantic-core"
+version = "2.41.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/71/70/23b021c950c2addd24ec408e9ab05d59b035b39d97cdc1130e1bce647bb6/pydantic_core-2.41.5.tar.gz", hash = "sha256:08daa51ea16ad373ffd5e7606252cc32f07bc72b28284b6bc9c6df804816476e", size = 460952, upload-time = "2025-11-04T13:43:49.098Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5f/5d/5f6c63eebb5afee93bcaae4ce9a898f3373ca23df3ccaef086d0233a35a7/pydantic_core-2.41.5-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:f41a7489d32336dbf2199c8c0a215390a751c5b014c2c1c5366e817202e9cdf7", size = 2110990, upload-time = "2025-11-04T13:39:58.079Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/32/9c2e8ccb57c01111e0fd091f236c7b371c1bccea0fa85247ac55b1e2b6b6/pydantic_core-2.41.5-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:070259a8818988b9a84a449a2a7337c7f430a22acc0859c6b110aa7212a6d9c0", size = 1896003, upload-time = "2025-11-04T13:39:59.956Z" },
+    { url = "https://files.pythonhosted.org/packages/68/b8/a01b53cb0e59139fbc9e4fda3e9724ede8de279097179be4ff31f1abb65a/pydantic_core-2.41.5-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e96cea19e34778f8d59fe40775a7a574d95816eb150850a85a7a4c8f4b94ac69", size = 1919200, upload-time = "2025-11-04T13:40:02.241Z" },
+    { url = "https://files.pythonhosted.org/packages/38/de/8c36b5198a29bdaade07b5985e80a233a5ac27137846f3bc2d3b40a47360/pydantic_core-2.41.5-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:ed2e99c456e3fadd05c991f8f437ef902e00eedf34320ba2b0842bd1c3ca3a75", size = 2052578, upload-time = "2025-11-04T13:40:04.401Z" },
+    { url = "https://files.pythonhosted.org/packages/00/b5/0e8e4b5b081eac6cb3dbb7e60a65907549a1ce035a724368c330112adfdd/pydantic_core-2.41.5-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:65840751b72fbfd82c3c640cff9284545342a4f1eb1586ad0636955b261b0b05", size = 2208504, upload-time = "2025-11-04T13:40:06.072Z" },
+    { url = "https://files.pythonhosted.org/packages/77/56/87a61aad59c7c5b9dc8caad5a41a5545cba3810c3e828708b3d7404f6cef/pydantic_core-2.41.5-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e536c98a7626a98feb2d3eaf75944ef6f3dbee447e1f841eae16f2f0a72d8ddc", size = 2335816, upload-time = "2025-11-04T13:40:07.835Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/76/941cc9f73529988688a665a5c0ecff1112b3d95ab48f81db5f7606f522d3/pydantic_core-2.41.5-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:eceb81a8d74f9267ef4081e246ffd6d129da5d87e37a77c9bde550cb04870c1c", size = 2075366, upload-time = "2025-11-04T13:40:09.804Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/43/ebef01f69baa07a482844faaa0a591bad1ef129253ffd0cdaa9d8a7f72d3/pydantic_core-2.41.5-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:d38548150c39b74aeeb0ce8ee1d8e82696f4a4e16ddc6de7b1d8823f7de4b9b5", size = 2171698, upload-time = "2025-11-04T13:40:12.004Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/87/41f3202e4193e3bacfc2c065fab7706ebe81af46a83d3e27605029c1f5a6/pydantic_core-2.41.5-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:c23e27686783f60290e36827f9c626e63154b82b116d7fe9adba1fda36da706c", size = 2132603, upload-time = "2025-11-04T13:40:13.868Z" },
+    { url = "https://files.pythonhosted.org/packages/49/7d/4c00df99cb12070b6bccdef4a195255e6020a550d572768d92cc54dba91a/pydantic_core-2.41.5-cp312-cp312-musllinux_1_1_armv7l.whl", hash = "sha256:482c982f814460eabe1d3bb0adfdc583387bd4691ef00b90575ca0d2b6fe2294", size = 2329591, upload-time = "2025-11-04T13:40:15.672Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/6a/ebf4b1d65d458f3cda6a7335d141305dfa19bdc61140a884d165a8a1bbc7/pydantic_core-2.41.5-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:bfea2a5f0b4d8d43adf9d7b8bf019fb46fdd10a2e5cde477fbcb9d1fa08c68e1", size = 2319068, upload-time = "2025-11-04T13:40:17.532Z" },
+    { url = "https://files.pythonhosted.org/packages/49/3b/774f2b5cd4192d5ab75870ce4381fd89cf218af999515baf07e7206753f0/pydantic_core-2.41.5-cp312-cp312-win32.whl", hash = "sha256:b74557b16e390ec12dca509bce9264c3bbd128f8a2c376eaa68003d7f327276d", size = 1985908, upload-time = "2025-11-04T13:40:19.309Z" },
+    { url = "https://files.pythonhosted.org/packages/86/45/00173a033c801cacf67c190fef088789394feaf88a98a7035b0e40d53dc9/pydantic_core-2.41.5-cp312-cp312-win_amd64.whl", hash = "sha256:1962293292865bca8e54702b08a4f26da73adc83dd1fcf26fbc875b35d81c815", size = 2020145, upload-time = "2025-11-04T13:40:21.548Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/22/91fbc821fa6d261b376a3f73809f907cec5ca6025642c463d3488aad22fb/pydantic_core-2.41.5-cp312-cp312-win_arm64.whl", hash = "sha256:1746d4a3d9a794cacae06a5eaaccb4b8643a131d45fbc9af23e353dc0a5ba5c3", size = 1976179, upload-time = "2025-11-04T13:40:23.393Z" },
+    { url = "https://files.pythonhosted.org/packages/09/32/59b0c7e63e277fa7911c2fc70ccfb45ce4b98991e7ef37110663437005af/pydantic_core-2.41.5-graalpy312-graalpy250_312_native-macosx_10_12_x86_64.whl", hash = "sha256:7da7087d756b19037bc2c06edc6c170eeef3c3bafcb8f532ff17d64dc427adfd", size = 2110495, upload-time = "2025-11-04T13:42:49.689Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/81/05e400037eaf55ad400bcd318c05bb345b57e708887f07ddb2d20e3f0e98/pydantic_core-2.41.5-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:aabf5777b5c8ca26f7824cb4a120a740c9588ed58df9b2d196ce92fba42ff8dc", size = 1915388, upload-time = "2025-11-04T13:42:52.215Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/0d/e3549b2399f71d56476b77dbf3cf8937cec5cd70536bdc0e374a421d0599/pydantic_core-2.41.5-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c007fe8a43d43b3969e8469004e9845944f1a80e6acd47c150856bb87f230c56", size = 1942879, upload-time = "2025-11-04T13:42:56.483Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/07/34573da085946b6a313d7c42f82f16e8920bfd730665de2d11c0c37a74b5/pydantic_core-2.41.5-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:76d0819de158cd855d1cbb8fcafdf6f5cf1eb8e470abe056d5d161106e38062b", size = 2139017, upload-time = "2025-11-04T13:42:59.471Z" },
 ]
 
 [[package]]
 name = "pyflakes"
 version = "3.1.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/8b/fb/7251eaec19a055ec6aafb3d1395db7622348130d1b9b763f78567b2aab32/pyflakes-3.1.0.tar.gz", hash = "sha256:a0aae034c444db0071aa077972ba4768d40c830d9539fd45bf4cd3f8f6992efc", size = 63636 }
+sdist = { url = "https://files.pythonhosted.org/packages/8b/fb/7251eaec19a055ec6aafb3d1395db7622348130d1b9b763f78567b2aab32/pyflakes-3.1.0.tar.gz", hash = "sha256:a0aae034c444db0071aa077972ba4768d40c830d9539fd45bf4cd3f8f6992efc", size = 63636, upload-time = "2023-07-29T17:00:41.482Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/00/e9/1e1fd7fae559bfd07704991e9a59dd1349b72423c904256c073ce88a9940/pyflakes-3.1.0-py2.py3-none-any.whl", hash = "sha256:4132f6d49cb4dae6819e5379898f2b8cce3c5f23994194c24b77d5da2e36f774", size = 62616 },
+    { url = "https://files.pythonhosted.org/packages/00/e9/1e1fd7fae559bfd07704991e9a59dd1349b72423c904256c073ce88a9940/pyflakes-3.1.0-py2.py3-none-any.whl", hash = "sha256:4132f6d49cb4dae6819e5379898f2b8cce3c5f23994194c24b77d5da2e36f774", size = 62616, upload-time = "2023-07-29T17:00:40.344Z" },
 ]
 
 [[package]]
@@ -388,18 +544,18 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "dnspython" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/37/a5/e466796ebc3ca04414ace520947bb5af3cef923fc75896fc54051405b68d/pymongo-4.15.0.tar.gz", hash = "sha256:430a6dc088355209e5755f77d85ddea2f1da0bb6123185952a573e7cf25a250a", size = 2469214 }
+sdist = { url = "https://files.pythonhosted.org/packages/37/a5/e466796ebc3ca04414ace520947bb5af3cef923fc75896fc54051405b68d/pymongo-4.15.0.tar.gz", hash = "sha256:430a6dc088355209e5755f77d85ddea2f1da0bb6123185952a573e7cf25a250a", size = 2469214, upload-time = "2025-09-10T16:46:53.533Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/47/07/982f2a066c637d488474c60a18de69b9a067598789d093a84dd0ef2f229b/pymongo-4.15.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:614fc7625019b78b19f2e47fc78c2d66f8d266b57aaedcb8044d909b9a48b49c", size = 919602 },
-    { url = "https://files.pythonhosted.org/packages/59/37/4470afa034dd12ec134a358fb863cd8e16f395b2838d7642679299ff63cf/pymongo-4.15.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:bd4a7360dd37e983712fe032eea71e6d59cdfb86e4e171a38425bd0570fef0af", size = 919297 },
-    { url = "https://files.pythonhosted.org/packages/cb/b8/0cc92fa56f357b3c58293f291fca378b70287ec31e9e01649e43ea0f3e8d/pymongo-4.15.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5169b10686b43bc1ac437ce8ba3447cccb91181c9d229813d94321b833229230", size = 1697937 },
-    { url = "https://files.pythonhosted.org/packages/b2/48/156f4fd9078dabc7320aa6bb9ed8c2b890096a3a3acdbf86cbf4c92ab75c/pymongo-4.15.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e084bb5a28a1a4887096806ed1d09faedece86098e5bb34ea425326e04393a1d", size = 1762171 },
-    { url = "https://files.pythonhosted.org/packages/5f/50/87c7e9901d1183689790abaa58cb6e64da3f9b892bea23453e86aab0ba5e/pymongo-4.15.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f646f1d5235ccdb9f58b7bc6d12ec15bbd4275ec993b3623e065d85b21d60ab5", size = 1731216 },
-    { url = "https://files.pythonhosted.org/packages/5b/7c/3b4c0ef65509129a9426a66447a47816845628e5fd0e067a8c30fdf1ce97/pymongo-4.15.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b2f13893f0d4e9b5c0e9f63f4538479a904d3d97f0907ea1b6f83bf1bc9b1f84", size = 1701192 },
-    { url = "https://files.pythonhosted.org/packages/b3/6b/2d0cfc2e2d099a650a750b0130fc9644af9a5bac4c26a785581cc79be702/pymongo-4.15.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:4d77e199cb2eb52e1d2682fdbf6523ab899b6b2211e4486a3dbc1b7efd8c6133", size = 1660319 },
-    { url = "https://files.pythonhosted.org/packages/dc/cf/25343aef57bf37abdf199672e0fd086ee5f18addb5b3c9af515a69e1d672/pymongo-4.15.0-cp312-cp312-win32.whl", hash = "sha256:958aa856a7b53084623a9e01e5f64969cab387461ca99b79a6137283cf413a2a", size = 890499 },
-    { url = "https://files.pythonhosted.org/packages/4c/8d/3426711f9f30702bd0a63394b09f71695c4fa69028dfeaa7aeb5c3579d41/pymongo-4.15.0-cp312-cp312-win_amd64.whl", hash = "sha256:753d74b1d21c912d39654a44ef9d8f09ffda92587e5555ab861459c0beebd9df", size = 909950 },
-    { url = "https://files.pythonhosted.org/packages/2d/0c/ac344fa94d303af61bbad53fcf43a430b9ccac21c65106cfe9ae1ca2986b/pymongo-4.15.0-cp312-cp312-win_arm64.whl", hash = "sha256:00774f378b354f3e50446f9b48d7c3a6361695d7b4adc156cc6970d6c6bed557", size = 895554 },
+    { url = "https://files.pythonhosted.org/packages/47/07/982f2a066c637d488474c60a18de69b9a067598789d093a84dd0ef2f229b/pymongo-4.15.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:614fc7625019b78b19f2e47fc78c2d66f8d266b57aaedcb8044d909b9a48b49c", size = 919602, upload-time = "2025-09-10T16:45:21.127Z" },
+    { url = "https://files.pythonhosted.org/packages/59/37/4470afa034dd12ec134a358fb863cd8e16f395b2838d7642679299ff63cf/pymongo-4.15.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:bd4a7360dd37e983712fe032eea71e6d59cdfb86e4e171a38425bd0570fef0af", size = 919297, upload-time = "2025-09-10T16:45:22.711Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/b8/0cc92fa56f357b3c58293f291fca378b70287ec31e9e01649e43ea0f3e8d/pymongo-4.15.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5169b10686b43bc1ac437ce8ba3447cccb91181c9d229813d94321b833229230", size = 1697937, upload-time = "2025-09-10T16:45:24.582Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/48/156f4fd9078dabc7320aa6bb9ed8c2b890096a3a3acdbf86cbf4c92ab75c/pymongo-4.15.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e084bb5a28a1a4887096806ed1d09faedece86098e5bb34ea425326e04393a1d", size = 1762171, upload-time = "2025-09-10T16:45:26.197Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/50/87c7e9901d1183689790abaa58cb6e64da3f9b892bea23453e86aab0ba5e/pymongo-4.15.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f646f1d5235ccdb9f58b7bc6d12ec15bbd4275ec993b3623e065d85b21d60ab5", size = 1731216, upload-time = "2025-09-10T16:45:28.273Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/7c/3b4c0ef65509129a9426a66447a47816845628e5fd0e067a8c30fdf1ce97/pymongo-4.15.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b2f13893f0d4e9b5c0e9f63f4538479a904d3d97f0907ea1b6f83bf1bc9b1f84", size = 1701192, upload-time = "2025-09-10T16:45:30.405Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/6b/2d0cfc2e2d099a650a750b0130fc9644af9a5bac4c26a785581cc79be702/pymongo-4.15.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:4d77e199cb2eb52e1d2682fdbf6523ab899b6b2211e4486a3dbc1b7efd8c6133", size = 1660319, upload-time = "2025-09-10T16:45:32.547Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/cf/25343aef57bf37abdf199672e0fd086ee5f18addb5b3c9af515a69e1d672/pymongo-4.15.0-cp312-cp312-win32.whl", hash = "sha256:958aa856a7b53084623a9e01e5f64969cab387461ca99b79a6137283cf413a2a", size = 890499, upload-time = "2025-09-10T16:45:34.455Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/8d/3426711f9f30702bd0a63394b09f71695c4fa69028dfeaa7aeb5c3579d41/pymongo-4.15.0-cp312-cp312-win_amd64.whl", hash = "sha256:753d74b1d21c912d39654a44ef9d8f09ffda92587e5555ab861459c0beebd9df", size = 909950, upload-time = "2025-09-10T16:45:36.532Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/0c/ac344fa94d303af61bbad53fcf43a430b9ccac21c65106cfe9ae1ca2986b/pymongo-4.15.0-cp312-cp312-win_arm64.whl", hash = "sha256:00774f378b354f3e50446f9b48d7c3a6361695d7b4adc156cc6970d6c6bed557", size = 895554, upload-time = "2025-09-10T16:45:38.388Z" },
 ]
 
 [[package]]
@@ -412,9 +568,9 @@ dependencies = [
     { name = "packaging" },
     { name = "pluggy" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/80/1f/9d8e98e4133ffb16c90f3b405c43e38d3abb715bb5d7a63a5a684f7e46a3/pytest-7.4.4.tar.gz", hash = "sha256:2cf0005922c6ace4a3e2ec8b4080eb0d9753fdc93107415332f50ce9e7994280", size = 1357116 }
+sdist = { url = "https://files.pythonhosted.org/packages/80/1f/9d8e98e4133ffb16c90f3b405c43e38d3abb715bb5d7a63a5a684f7e46a3/pytest-7.4.4.tar.gz", hash = "sha256:2cf0005922c6ace4a3e2ec8b4080eb0d9753fdc93107415332f50ce9e7994280", size = 1357116, upload-time = "2023-12-31T12:00:18.035Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/51/ff/f6e8b8f39e08547faece4bd80f89d5a8de68a38b2d179cc1c4490ffa3286/pytest-7.4.4-py3-none-any.whl", hash = "sha256:b090cdf5ed60bf4c45261be03239c2c1c22df034fbffe691abe93cd80cea01d8", size = 325287 },
+    { url = "https://files.pythonhosted.org/packages/51/ff/f6e8b8f39e08547faece4bd80f89d5a8de68a38b2d179cc1c4490ffa3286/pytest-7.4.4-py3-none-any.whl", hash = "sha256:b090cdf5ed60bf4c45261be03239c2c1c22df034fbffe691abe93cd80cea01d8", size = 325287, upload-time = "2023-12-31T12:00:13.963Z" },
 ]
 
 [[package]]
@@ -425,9 +581,9 @@ dependencies = [
     { name = "coverage" },
     { name = "pytest" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/7a/15/da3df99fd551507694a9b01f512a2f6cf1254f33601605843c3775f39460/pytest-cov-4.1.0.tar.gz", hash = "sha256:3904b13dfbfec47f003b8e77fd5b589cd11904a21ddf1ab38a64f204d6a10ef6", size = 63245 }
+sdist = { url = "https://files.pythonhosted.org/packages/7a/15/da3df99fd551507694a9b01f512a2f6cf1254f33601605843c3775f39460/pytest-cov-4.1.0.tar.gz", hash = "sha256:3904b13dfbfec47f003b8e77fd5b589cd11904a21ddf1ab38a64f204d6a10ef6", size = 63245, upload-time = "2023-05-24T18:44:56.845Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a7/4b/8b78d126e275efa2379b1c2e09dc52cf70df16fc3b90613ef82531499d73/pytest_cov-4.1.0-py3-none-any.whl", hash = "sha256:6ba70b9e97e69fcc3fb45bfeab2d0a138fb65c4d0d6a41ef33983ad114be8c3a", size = 21949 },
+    { url = "https://files.pythonhosted.org/packages/a7/4b/8b78d126e275efa2379b1c2e09dc52cf70df16fc3b90613ef82531499d73/pytest_cov-4.1.0-py3-none-any.whl", hash = "sha256:6ba70b9e97e69fcc3fb45bfeab2d0a138fb65c4d0d6a41ef33983ad114be8c3a", size = 21949, upload-time = "2023-05-24T18:44:54.079Z" },
 ]
 
 [[package]]
@@ -437,27 +593,27 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "six" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432 }
+sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432, upload-time = "2024-03-01T18:36:20.211Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892 },
+    { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892, upload-time = "2024-03-01T18:36:18.57Z" },
 ]
 
 [[package]]
 name = "python-dotenv"
 version = "1.1.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f6/b0/4bc07ccd3572a2f9df7e6782f52b0c6c90dcbb803ac4a167702d7d0dfe1e/python_dotenv-1.1.1.tar.gz", hash = "sha256:a8a6399716257f45be6a007360200409fce5cda2661e3dec71d23dc15f6189ab", size = 41978 }
+sdist = { url = "https://files.pythonhosted.org/packages/f6/b0/4bc07ccd3572a2f9df7e6782f52b0c6c90dcbb803ac4a167702d7d0dfe1e/python_dotenv-1.1.1.tar.gz", hash = "sha256:a8a6399716257f45be6a007360200409fce5cda2661e3dec71d23dc15f6189ab", size = 41978, upload-time = "2025-06-24T04:21:07.341Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5f/ed/539768cf28c661b5b068d66d96a2f155c4971a5d55684a514c1a0e0dec2f/python_dotenv-1.1.1-py3-none-any.whl", hash = "sha256:31f23644fe2602f88ff55e1f5c79ba497e01224ee7737937930c448e4d0e24dc", size = 20556 },
+    { url = "https://files.pythonhosted.org/packages/5f/ed/539768cf28c661b5b068d66d96a2f155c4971a5d55684a514c1a0e0dec2f/python_dotenv-1.1.1-py3-none-any.whl", hash = "sha256:31f23644fe2602f88ff55e1f5c79ba497e01224ee7737937930c448e4d0e24dc", size = 20556, upload-time = "2025-06-24T04:21:06.073Z" },
 ]
 
 [[package]]
 name = "pytz"
 version = "2025.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f8/bf/abbd3cdfb8fbc7fb3d4d38d320f2441b1e7cbe29be4f23797b4a2b5d8aac/pytz-2025.2.tar.gz", hash = "sha256:360b9e3dbb49a209c21ad61809c7fb453643e048b38924c765813546746e81c3", size = 320884 }
+sdist = { url = "https://files.pythonhosted.org/packages/f8/bf/abbd3cdfb8fbc7fb3d4d38d320f2441b1e7cbe29be4f23797b4a2b5d8aac/pytz-2025.2.tar.gz", hash = "sha256:360b9e3dbb49a209c21ad61809c7fb453643e048b38924c765813546746e81c3", size = 320884, upload-time = "2025-03-25T02:25:00.538Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/81/c4/34e93fe5f5429d7570ec1fa436f1986fb1f00c3e0f43a589fe2bbcd22c3f/pytz-2025.2-py2.py3-none-any.whl", hash = "sha256:5ddf76296dd8c44c26eb8f4b6f35488f3ccbf6fbbd7adee0b7262d43f0ec2f00", size = 509225 },
+    { url = "https://files.pythonhosted.org/packages/81/c4/34e93fe5f5429d7570ec1fa436f1986fb1f00c3e0f43a589fe2bbcd22c3f/pytz-2025.2-py2.py3-none-any.whl", hash = "sha256:5ddf76296dd8c44c26eb8f4b6f35488f3ccbf6fbbd7adee0b7262d43f0ec2f00", size = 509225, upload-time = "2025-03-25T02:24:58.468Z" },
 ]
 
 [[package]]
@@ -470,9 +626,9 @@ dependencies = [
     { name = "idna" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c9/74/b3ff8e6c8446842c3f5c837e9c3dfcfe2018ea6ecef224c710c85ef728f4/requests-2.32.5.tar.gz", hash = "sha256:dbba0bac56e100853db0ea71b82b4dfd5fe2bf6d3754a8893c3af500cec7d7cf", size = 134517 }
+sdist = { url = "https://files.pythonhosted.org/packages/c9/74/b3ff8e6c8446842c3f5c837e9c3dfcfe2018ea6ecef224c710c85ef728f4/requests-2.32.5.tar.gz", hash = "sha256:dbba0bac56e100853db0ea71b82b4dfd5fe2bf6d3754a8893c3af500cec7d7cf", size = 134517, upload-time = "2025-08-18T20:46:02.573Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1e/db/4254e3eabe8020b458f1a747140d32277ec7a271daf1d235b70dc0b4e6e3/requests-2.32.5-py3-none-any.whl", hash = "sha256:2462f94637a34fd532264295e186976db0f5d453d1cdd31473c85a6a161affb6", size = 64738 },
+    { url = "https://files.pythonhosted.org/packages/1e/db/4254e3eabe8020b458f1a747140d32277ec7a271daf1d235b70dc0b4e6e3/requests-2.32.5-py3-none-any.whl", hash = "sha256:2462f94637a34fd532264295e186976db0f5d453d1cdd31473c85a6a161affb6", size = 64738, upload-time = "2025-08-18T20:46:00.542Z" },
 ]
 
 [[package]]
@@ -482,27 +638,36 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "requests" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/72/97/bf44e6c6bd8ddbb99943baf7ba8b1a8485bcd2fe0e55e5708d7fee4ff1ae/requests_file-2.1.0.tar.gz", hash = "sha256:0f549a3f3b0699415ac04d167e9cb39bccfb730cb832b4d20be3d9867356e658", size = 6891 }
+sdist = { url = "https://files.pythonhosted.org/packages/72/97/bf44e6c6bd8ddbb99943baf7ba8b1a8485bcd2fe0e55e5708d7fee4ff1ae/requests_file-2.1.0.tar.gz", hash = "sha256:0f549a3f3b0699415ac04d167e9cb39bccfb730cb832b4d20be3d9867356e658", size = 6891, upload-time = "2024-05-21T16:28:00.24Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d7/25/dd878a121fcfdf38f52850f11c512e13ec87c2ea72385933818e5b6c15ce/requests_file-2.1.0-py2.py3-none-any.whl", hash = "sha256:cf270de5a4c5874e84599fc5778303d496c10ae5e870bfa378818f35d21bda5c", size = 4244 },
+    { url = "https://files.pythonhosted.org/packages/d7/25/dd878a121fcfdf38f52850f11c512e13ec87c2ea72385933818e5b6c15ce/requests_file-2.1.0-py2.py3-none-any.whl", hash = "sha256:cf270de5a4c5874e84599fc5778303d496c10ae5e870bfa378818f35d21bda5c", size = 4244, upload-time = "2024-05-21T16:27:57.733Z" },
 ]
 
 [[package]]
 name = "six"
 version = "1.17.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031 }
+sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050 },
+    { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
+]
+
+[[package]]
+name = "sniffio"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372, upload-time = "2024-02-25T23:20:04.057Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235, upload-time = "2024-02-25T23:20:01.196Z" },
 ]
 
 [[package]]
 name = "soupsieve"
 version = "2.8"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/6d/e6/21ccce3262dd4889aa3332e5a119a3491a95e8f60939870a3a035aabac0d/soupsieve-2.8.tar.gz", hash = "sha256:e2dd4a40a628cb5f28f6d4b0db8800b8f581b65bb380b97de22ba5ca8d72572f", size = 103472 }
+sdist = { url = "https://files.pythonhosted.org/packages/6d/e6/21ccce3262dd4889aa3332e5a119a3491a95e8f60939870a3a035aabac0d/soupsieve-2.8.tar.gz", hash = "sha256:e2dd4a40a628cb5f28f6d4b0db8800b8f581b65bb380b97de22ba5ca8d72572f", size = 103472, upload-time = "2025-08-27T15:39:51.78Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/14/a0/bb38d3b76b8cae341dad93a2dd83ab7462e6dbcdd84d43f54ee60a8dc167/soupsieve-2.8-py3-none-any.whl", hash = "sha256:0cc76456a30e20f5d7f2e14a98a4ae2ee4e5abdc7c5ea0aafe795f344bc7984c", size = 36679 },
+    { url = "https://files.pythonhosted.org/packages/14/a0/bb38d3b76b8cae341dad93a2dd83ab7462e6dbcdd84d43f54ee60a8dc167/soupsieve-2.8-py3-none-any.whl", hash = "sha256:0cc76456a30e20f5d7f2e14a98a4ae2ee4e5abdc7c5ea0aafe795f344bc7984c", size = 36679, upload-time = "2025-08-27T15:39:50.179Z" },
 ]
 
 [[package]]
@@ -510,9 +675,11 @@ name = "stockelper-kg"
 version = "0.1.0"
 source = { editable = "." }
 dependencies = [
+    { name = "beautifulsoup4" },
     { name = "finance-datareader" },
     { name = "neo4j" },
     { name = "numpy" },
+    { name = "openai" },
     { name = "opendartreader" },
     { name = "pandas" },
     { name = "pymongo" },
@@ -533,9 +700,11 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "beautifulsoup4", specifier = ">=4.9.0" },
     { name = "finance-datareader", specifier = ">=0.9.90,<1.0" },
     { name = "neo4j", specifier = ">=5.11,<6" },
     { name = "numpy", specifier = ">=1.24,<3.0" },
+    { name = "openai", specifier = ">=1.0.0" },
     { name = "opendartreader", specifier = ">=0.2.3,<0.3" },
     { name = "pandas", specifier = ">=2.0,<3.0" },
     { name = "pymongo", specifier = ">=4.3,<5" },
@@ -561,34 +730,46 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a8/4b/29b4ef32e036bb34e4ab51796dd745cdba7ed47ad142a9f4a1eb8e0c744d/tqdm-4.67.1.tar.gz", hash = "sha256:f8aef9c52c08c13a65f30ea34f4e5aac3fd1a34959879d7e59e63027286627f2", size = 169737 }
+sdist = { url = "https://files.pythonhosted.org/packages/a8/4b/29b4ef32e036bb34e4ab51796dd745cdba7ed47ad142a9f4a1eb8e0c744d/tqdm-4.67.1.tar.gz", hash = "sha256:f8aef9c52c08c13a65f30ea34f4e5aac3fd1a34959879d7e59e63027286627f2", size = 169737, upload-time = "2024-11-24T20:12:22.481Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d0/30/dc54f88dd4a2b5dc8a0279bdd7270e735851848b762aeb1c1184ed1f6b14/tqdm-4.67.1-py3-none-any.whl", hash = "sha256:26445eca388f82e72884e0d580d5464cd801a3ea01e63e5601bdff9ba6a48de2", size = 78540 },
+    { url = "https://files.pythonhosted.org/packages/d0/30/dc54f88dd4a2b5dc8a0279bdd7270e735851848b762aeb1c1184ed1f6b14/tqdm-4.67.1-py3-none-any.whl", hash = "sha256:26445eca388f82e72884e0d580d5464cd801a3ea01e63e5601bdff9ba6a48de2", size = 78540, upload-time = "2024-11-24T20:12:19.698Z" },
 ]
 
 [[package]]
 name = "typing-extensions"
 version = "4.15.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391 }
+sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614 },
+    { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
+]
+
+[[package]]
+name = "typing-inspection"
+version = "0.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
 ]
 
 [[package]]
 name = "tzdata"
 version = "2025.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/95/32/1a225d6164441be760d75c2c42e2780dc0873fe382da3e98a2e1e48361e5/tzdata-2025.2.tar.gz", hash = "sha256:b60a638fcc0daffadf82fe0f57e53d06bdec2f36c4df66280ae79bce6bd6f2b9", size = 196380 }
+sdist = { url = "https://files.pythonhosted.org/packages/95/32/1a225d6164441be760d75c2c42e2780dc0873fe382da3e98a2e1e48361e5/tzdata-2025.2.tar.gz", hash = "sha256:b60a638fcc0daffadf82fe0f57e53d06bdec2f36c4df66280ae79bce6bd6f2b9", size = 196380, upload-time = "2025-03-23T13:54:43.652Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5c/23/c7abc0ca0a1526a0774eca151daeb8de62ec457e77262b66b359c3c7679e/tzdata-2025.2-py2.py3-none-any.whl", hash = "sha256:1a403fada01ff9221ca8044d701868fa132215d84beb92242d9acd2147f667a8", size = 347839 },
+    { url = "https://files.pythonhosted.org/packages/5c/23/c7abc0ca0a1526a0774eca151daeb8de62ec457e77262b66b359c3c7679e/tzdata-2025.2-py2.py3-none-any.whl", hash = "sha256:1a403fada01ff9221ca8044d701868fa132215d84beb92242d9acd2147f667a8", size = 347839, upload-time = "2025-03-23T13:54:41.845Z" },
 ]
 
 [[package]]
 name = "urllib3"
 version = "2.5.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/15/22/9ee70a2574a4f4599c47dd506532914ce044817c7752a79b6a51286319bc/urllib3-2.5.0.tar.gz", hash = "sha256:3fc47733c7e419d4bc3f6b3dc2b4f890bb743906a30d56ba4a5bfa4bbff92760", size = 393185 }
+sdist = { url = "https://files.pythonhosted.org/packages/15/22/9ee70a2574a4f4599c47dd506532914ce044817c7752a79b6a51286319bc/urllib3-2.5.0.tar.gz", hash = "sha256:3fc47733c7e419d4bc3f6b3dc2b4f890bb743906a30d56ba4a5bfa4bbff92760", size = 393185, upload-time = "2025-06-18T14:07:41.644Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a7/c2/fe1e52489ae3122415c51f387e221dd0773709bad6c6cdaa599e8a2c5185/urllib3-2.5.0-py3-none-any.whl", hash = "sha256:e6b01673c0fa6a13e374b50871808eb3bf7046c4b125b216f6bf1cc604cff0dc", size = 129795 },
+    { url = "https://files.pythonhosted.org/packages/a7/c2/fe1e52489ae3122415c51f387e221dd0773709bad6c6cdaa599e8a2c5185/urllib3-2.5.0-py3-none-any.whl", hash = "sha256:e6b01673c0fa6a13e374b50871808eb3bf7046c4b125b216f6bf1cc604cff0dc", size = 129795, upload-time = "2025-06-18T14:07:40.39Z" },
 ]


### PR DESCRIPTION
## 온톨로지 구현

### 0. 이벤트 온톨로지 스키마
https://www.notion.so/2c35fda040b5805f8404ce321e881c03

### 1. 회사 정보 지식 그래프 (기존 구현)

이벤트 그래프와 매핑되도록 일부 구현 통일 (date)

### 2. 이벤트 지식 그래프 구축

이벤트(뉴스) 프롬프트가 들어오면 이벤트 그래프 생성

### 3. 회사~이벤트 지식 그래프 연결

|그럼1|그림2|
|--|--|
<img width="1461" height="961" alt="image" src="https://github.com/user-attachments/assets/cf8acc75-f37e-4c80-96ad-f11eaa4940a4" />|<img width="1677" height="926" alt="image" src="https://github.com/user-attachments/assets/267d4659-5158-4a10-9f01-ad5e2967d6e7" />|

### 병렬 처리

기존 코드는 배치 사이즈를 사용하고 있으나, 실질적으로 직렬 처리가 되고있어 배치 사이즈의 크기가 실행 속도에 영향을 주지 못하고 있었음.

thread를 도입해 분할적으로 작업을 실행할 수 있도록 함

약 25분 정도 걸리던 작업을, 6~9분까지 속도 절감 (4 thread 기준)

```python3
2025-12-08 13:06:15,075 - stockelper_kg.utils.decorators - INFO - Total Time: 00:07:04
```

## TODO 및 고민점

### Entity Resolution

뉴스 데이터에서 뽑은 데이터를 Neo4j에 있는 노드에 어떻게 넣을 것인가?

- Entity Resolution: 어떻게 같은 엔티티로 통일시킬 것인가? (e.g SK하이닉스, SKHynix .. )
- Entity Linking: 어디에 속하는 노드인지 아는가? (Facility? Product? ... )

### Multi Event

- 이벤트가 여러개 나올 수 있거나, 회사 관련 노드가 여러개 나올 수 있는 경우 처리
    - 기아-현대차 일 경우, Company.corp_name: 기아, Company.corp_name: 현대차 두개로 분리
    - 여러개 이벤트 분리 나올 수 있는 경우 분리

### 실시간 이벤트 처리

- airflow와 연동해서 처리 필요

### 경쟁사 연결

- MongoDB 연결이 되지 않아 경쟁사 관련 정보 확인하지 못했음.