### PR TITLE
feat/multi-events

### DIFF
--- a/src/stockelper_kg/event_cli.py
+++ b/src/stockelper_kg/event_cli.py
@@ -92,18 +92,45 @@ def _run_pipeline(
     for idx, item in enumerate(items, start=1):
         logger.info("[%d/%d] Processing %s", idx, total, item.identifier)
         try:
-            event_data = pipeline.process(item.text, metadata=item.metadata)
-            event_type = event_data.get("event_type", "UNKNOWN")
-            logger.info("[%s] ✓ event_type=%s", item.identifier, event_type)
-            results.append(
-                {
-                    "source": item.identifier,
-                    "success": True,
-                    "event_type": event_type,
-                    "metadata": item.metadata,
-                    "result": event_data,
-                }
-            )
+            event_results = pipeline.process(item.text, metadata=item.metadata)
+            if not isinstance(event_results, list):
+                event_results = [event_results]
+            if not event_results:
+                results.append(
+                    {
+                        "source": item.identifier,
+                        "success": False,
+                        "metadata": item.metadata,
+                        "error": "No events returned",
+                    }
+                )
+                continue
+
+            total_events = len(event_results)
+            for event_idx, event_data in enumerate(event_results, start=1):
+                event_type = event_data.get("event_type", "UNKNOWN")
+                corps = event_data.get("corp_names") or [event_data.get("corp_name")]
+                corp_label = ", ".join([c for c in corps if c]) or "UNKNOWN"
+                logger.info(
+                    "[%s] ✓ event %d/%d type=%s corps=%s",
+                    item.identifier,
+                    event_idx,
+                    total_events,
+                    event_type,
+                    corp_label,
+                )
+                results.append(
+                    {
+                        "source": item.identifier,
+                        "success": True,
+                        "event_index": event_idx,
+                        "event_count": total_events,
+                        "event_type": event_type,
+                        "corps": corps,
+                        "metadata": item.metadata,
+                        "result": event_data,
+                    }
+                )
         except Exception as exc:
             logger.exception("[%s] ✗ processing failed", item.identifier)
             results.append(

--- a/src/stockelper_kg/event_cli.py
+++ b/src/stockelper_kg/event_cli.py
@@ -109,8 +109,9 @@ def _run_pipeline(
             total_events = len(event_results)
             for event_idx, event_data in enumerate(event_results, start=1):
                 event_type = event_data.get("event_type", "UNKNOWN")
-                corps = event_data.get("corp_names") or [event_data.get("corp_name")]
-                corp_label = ", ".join([c for c in corps if c]) or "UNKNOWN"
+                corps = event_data.get("corp_names")
+                corps_list = corps if isinstance(corps, list) else []
+                corp_label = ", ".join([c for c in corps_list if c]) or "UNKNOWN"
                 logger.info(
                     "[%s] ✓ event %d/%d type=%s corps=%s",
                     item.identifier,
@@ -126,7 +127,7 @@ def _run_pipeline(
                         "event_index": event_idx,
                         "event_count": total_events,
                         "event_type": event_type,
-                        "corps": corps,
+                        "corps": corps_list,
                         "metadata": item.metadata,
                         "result": event_data,
                     }

--- a/src/stockelper_kg/graph/event.py
+++ b/src/stockelper_kg/graph/event.py
@@ -17,26 +17,22 @@ client = OpenAI()
 logger = logging.getLogger(__name__)
 
 
-def classify_event(event: str, model: str = "gpt-4o-mini") -> dict[str, Any]:
-    event_text = event.strip() if event else ""
-    if not event_text:
+def classify_events(text: str, model: str = "gpt-4o-mini") -> list[dict[str, Any]]:
+    if not text or not text.strip():
         raise ValueError("event text is empty")
 
     ontology = build_ontology_prompts(detail="full")
     event_types = ", ".join(ONTOLOGY.event_map.keys())
 
     system_prompt = f"""You are a financial news event classification expert specializing in Korean stock market news.
-Analyze Korean news/event text to classify into ontology event types, extract structured slots, and calculate sentiment score.
+Detect all distinct financial news/events in the text and extract structured slots.
 
 Task:
-1. Event classification: Classify into one event type from ontology. If multiple events exist, select the most significant one.
-2. Slot extraction:
-   - required_slots: ONLY slots in ontology's "required" list for chosen event_type
-   - optional_slots: Any other relevant information NOT in required list
-3. Sentiment analysis: Calculate sentiment_score between -1.0 (negative) and 1.0 (positive).
-   - Positive: earnings improvement (실적 개선), new contracts (신규 계약), technological innovation (기술 혁신), positive outlook (긍정적 전망), etc.
-   - Negative: earnings deterioration (실적 악화), increased risks (리스크 증가), negative outlook (부정적 전망), regulatory tightening (규제 강화), etc.
-   - Neutral: close to 0
+1) Identify every separate event mentioned (a document may contain multiple events).
+2) For each event, extract ALL participating company names in corp_names (list).
+3) Fill required_slots using ONLY the ontology's required fields for that event_type.
+4) Fill optional_slots with any other factual details.
+5) Calculate sentiment_score between -1.0 (negative) and 1.0 (positive) for each event.
 
 [EVENT ONTOLOGY]
 {json.dumps(ontology["events"], ensure_ascii=False, indent=2)}
@@ -45,20 +41,26 @@ Output must be in JSON format only."""
 
     user_prompt = f"""Analyze the following Korean news/event text.
 
-News information:
-- Text: {event.strip()}
-
 Output only in the following JSON format (no other explanation, JSON only):
 {{
-  "event_type": "<string>",  // One of {event_types}, or "OTHER" if none applies. Must match exactly.
-  "corp_name": "<string>",  // Korean company name exactly as it appears in the text (e.g., "삼성전자"). Use null if not mentioned.
-  "required_slots": {{ "<slot_name>": "<value>", ... }},  // ONLY slots in ontology's "required" list for chosen event_type
-  "optional_slots": {{ "<slot_name>": "<value>", ... }},  // Any other relevant info NOT in required list
-  "summary": "<string>",  // Key summary in 1 sentence
-  "sentiment_score": <float>,  // Real number between -1.0 (negative) and 1.0 (positive)
-  "reported_by": "<string>",  // Source identifier (e.g., "DART", "연합뉴스")
-  "reported_at": "<string>"  // Date in YYYY-MM-DD format
+  "events": [
+    {{
+      "event_type": "{event_types} (or OTHER if none applies)",
+      "corp_names": ["Company A", "Company B"],
+      "summary": "Maximum 3 sentence summary for this event only. and explain reason of sentiment score",
+      "required_slots": {{ ONLY slots in ontology's "required" list for chosen event_type}},
+      "optional_slots": {{ "product_id": "...", ... }},
+      "sentiment_score": -1.0(negative) ~ +1.0(positive),
+      "reported_by": "YYYY-MM-DD",
+      "reported_at": "<string>"
+    }}
+  ]
 }}
+- events array MUST NOT be empty. If no clear event, return one OTHER event with best-effort fields.
+- corp_names MUST include every company involved in that event (list, no duplicates).
+
+News information:
+{text.strip()}
 """
 
     resp = client.chat.completions.create(
@@ -69,43 +71,90 @@ Output only in the following JSON format (no other explanation, JSON only):
         ],
         temperature=0,
         response_format={"type": "json_object"},
-        max_tokens=600,
+        max_tokens=1200,
     )
 
-    content = resp.choices[0].message.content
+    events = _parse_events_response(resp.choices[0].message.content)
+    logger.info("Extracted %d event(s)", len(events))
+    return events
+
+
+def _parse_events_response(content: str) -> list[dict[str, Any]]:
+    content = content.strip()
+    if content.startswith("```"):
+        lines = content.split("\n")
+        content = "\n".join(lines[1:-1]) if len(lines) > 2 else content
+        content = content.lstrip("json").strip()
+
     try:
-        data = json.loads(content)
+        payload = json.loads(content)
     except json.JSONDecodeError as exc:
+        preview = content[:200] + "..." if len(content) > 200 else content
+        logger.error("Failed to parse JSON. Preview: %s", preview)
         raise ValueError(f"Failed to parse LLM response: {exc}") from exc
 
-    required_slots = data.get("required_slots") or {}
-    optional_slots = data.get("optional_slots") or {}
+    events = payload.get("events") or payload.get("event")
+    if isinstance(events, dict):
+        events = [events]
+    if not isinstance(events, list) or not events:
+        raise ValueError("LLM response did not include any events")
+
+    normalized: list[dict[str, Any]] = []
+    for idx, event in enumerate(events, start=1):
+        if not isinstance(event, dict):
+            raise ValueError(f"Event #{idx} is not an object")
+        normalized.append(_normalize_event_dict(event, idx))
+    return normalized
+
+
+def _normalize_event_dict(raw: dict[str, Any], idx: int) -> dict[str, Any]:
+    data = dict(raw)
+    data["required_slots"] = (
+        data["required_slots"] if isinstance(data.get("required_slots"), dict) else {}
+    )
+    data["optional_slots"] = (
+        data["optional_slots"] if isinstance(data.get("optional_slots"), dict) else {}
+    )
 
     if "sentiment_score" not in data:
-        raise ValueError("sentiment_score is required but not found in LLM response")
+        raise ValueError(f"sentiment_score is required but missing in event #{idx}")
     sentiment_score = float(data["sentiment_score"])
     if not (-1.0 <= sentiment_score <= 1.0):
         raise ValueError(
-            f"sentiment_score must be a number between -1.0 and 1.0, got: {sentiment_score}"
+            f"sentiment_score must be between -1.0 and 1.0, got: {sentiment_score} in event #{idx}"
         )
-
-    event_type = data.get("event_type")
-    if event_type not in ONTOLOGY.event_map:
-        event_type = "OTHER"
-
-    corp_name = (data.get("corp_name") or required_slots.get("corp_name") or "").strip()
-    if not corp_name:
-        raise ValueError("corp_name is required but not found in LLM response")
-    data["corp_name"] = corp_name
-    data["event_type"] = event_type
     data["sentiment_score"] = sentiment_score
-    data["required_slots"] = required_slots
-    data["optional_slots"] = optional_slots
 
-    if date := required_slots.get("date"):
+    etype = (data.get("event_type") or "OTHER").strip().upper()
+    if etype not in ONTOLOGY.event_map:
+        etype = "OTHER"
+    data["event_type"] = etype
+
+    corp_names: list[str] = []
+    for candidate in (
+        data.get("corp_names"),
+        data.get("corp_name"),
+        data["required_slots"].get("corp_names"),
+        data["required_slots"].get("corp_name"),
+        data["optional_slots"].get("corp_names"),
+        data["optional_slots"].get("corp_name"),
+    ):
+        if isinstance(candidate, list):
+            corp_names.extend(
+                str(name).strip() for name in candidate if str(name).strip()
+            )
+        elif isinstance(candidate, str) and candidate.strip():
+            corp_names.append(candidate.strip())
+
+    corp_names = list(dict.fromkeys(name for name in corp_names if name))
+    if not corp_names:
+        raise ValueError(f"corp_name is required but missing in event #{idx}")
+    data["corp_names"] = corp_names
+    data["corp_name"] = corp_names[0]
+
+    if date := data["required_slots"].get("date"):
         data["date"] = date
 
-    logger.info(f"Event: {data}")
     return data
 
 
@@ -118,5 +167,6 @@ if __name__ == "__main__":
     if not path.is_file():
         raise SystemExit(f"File not found: {path}")
 
-    result = classify_event(path.read_text(encoding="utf-8"))
+    text = path.read_text(encoding="utf-8")
+    result = classify_events(text)
     print(json.dumps(result, ensure_ascii=False, indent=2))

--- a/src/stockelper_kg/graph/event.py
+++ b/src/stockelper_kg/graph/event.py
@@ -10,6 +10,7 @@ from dotenv import load_dotenv
 from openai import OpenAI
 
 from .ontology import ONTOLOGY, build_ontology_prompts
+from .payload import _normalize_corp_names
 
 load_dotenv()
 
@@ -130,27 +131,16 @@ def _normalize_event_dict(raw: dict[str, Any], idx: int) -> dict[str, Any]:
         etype = "OTHER"
     data["event_type"] = etype
 
-    corp_names: list[str] = []
-    for candidate in (
+    names: list[str] = []
+    for source in (
         data.get("corp_names"),
-        data.get("corp_name"),
-        data["required_slots"].get("corp_names"),
-        data["required_slots"].get("corp_name"),
-        data["optional_slots"].get("corp_names"),
-        data["optional_slots"].get("corp_name"),
+        data.get("required_slots", {}).get("corp_names"),
+        data.get("optional_slots", {}).get("corp_names"),
     ):
-        if isinstance(candidate, list):
-            corp_names.extend(
-                str(name).strip() for name in candidate if str(name).strip()
-            )
-        elif isinstance(candidate, str) and candidate.strip():
-            corp_names.append(candidate.strip())
-
-    corp_names = list(dict.fromkeys(name for name in corp_names if name))
-    if not corp_names:
-        raise ValueError(f"corp_name is required but missing in event #{idx}")
+        if isinstance(source, list):
+            names.extend(source)
+    corp_names = _normalize_corp_names(names)
     data["corp_names"] = corp_names
-    data["corp_name"] = corp_names[0]
 
     if date := data["required_slots"].get("date"):
         data["date"] = date

--- a/src/stockelper_kg/graph/payload.py
+++ b/src/stockelper_kg/graph/payload.py
@@ -1,27 +1,71 @@
 from __future__ import annotations
 
 import hashlib
+import json
 import uuid
 from typing import Any
 
 from ..utils.dates import build_date_properties, normalize_date
-from .ontology import ONTOLOGY
-from .schema import GraphBuildContext, GraphNodeSpec, GraphPayload, clean_props
+from .ontology import ONTOLOGY, EventDefinition
+from .schema import (
+    GraphBuildContext,
+    GraphNodeSpec,
+    GraphPayload,
+    _has_value,
+    clean_props,
+)
 
 _EVENT_DEFINITIONS = ONTOLOGY.event_map
+_NODE_IDENTITIES = {
+    label: defs.primary_keys[0]
+    for label, defs in ONTOLOGY.node_map.items()
+    if defs.primary_keys
+}
 
 
-def _has_value(val: Any) -> bool:
-    if isinstance(val, str):
-        return bool(val.strip())
-    if isinstance(val, (list, tuple, set, dict)):
-        return bool(val)
-    return val is not None
+def build_multi_event_payload(
+    events_data: list[dict[str, Any]],
+    metadata: dict[str, Any] | None = None,
+) -> GraphPayload:
+    if not events_data:
+        raise ValueError("events_data cannot be empty")
+
+    context = GraphBuildContext()
+    doc_info = extract_document_info(metadata, events_data[0])
+    shared_doc_node = (
+        context.add_node("Document", doc_info, _identity_keys_for("Document"))
+        if doc_info
+        else None
+    )
+
+    for idx, event_data in enumerate(events_data, start=1):
+        try:
+            event_payload = build_graph_payload(
+                event_data, metadata=None, shared_doc_node=shared_doc_node
+            )
+        except Exception as exc:
+            event_type = event_data.get("event_type", "UNKNOWN")
+            corp = event_data.get("corp_names") or event_data.get("corp_name")
+            label = corp if isinstance(corp, str) else ", ".join(corp or [])
+            raise ValueError(
+                f"Failed to build payload for event #{idx} ({event_type} | {label}): {exc}"
+            ) from exc
+        for node in event_payload.nodes:
+            context.add_node(
+                node.label,
+                node.properties,
+                node.identity_keys or _identity_keys_for(node.label),
+            )
+        for edge in event_payload.edges:
+            context.add_edge(edge.type, edge.source, edge.target)
+
+    return context.to_payload()
 
 
 def build_graph_payload(
     event_data: dict[str, Any],
     metadata: dict[str, Any] | None = None,
+    shared_doc_node: GraphNodeSpec | None = None,
 ) -> GraphPayload:
     event_type = event_data.get("event_type")
     if not event_type:
@@ -40,30 +84,50 @@ def build_graph_payload(
     if sentiment_score is not None:
         slots["sentiment_score"] = sentiment_score
 
+    corp_names = _normalize_corp_names(event_data, slots)
+    if not corp_names:
+        raise ValueError("corp_name is required")
+    slots["corp_names"] = corp_names
+    slots["corp_name"] = corp_names[0]
+    event_data["corp_names"] = corp_names
+    event_data["corp_name"] = corp_names[0]
+
+    # TODO: Behavior Change - auto-fill counterparty from corp_names when missing
+    _autofill_counterparty(definition, slots, corp_names)
+
     missing = [s for s in definition.required_slots if not _has_value(slots.get(s))]
     if missing:
-        raise ValueError(f"Missing required slots: {', '.join(missing)}")
-
-    corp_name = (event_data.get("corp_name") or slots.get("corp_name") or "").strip()
-    if not corp_name:
-        raise ValueError("corp_name is required")
-    slots["corp_name"] = corp_name
+        missing_str = ", ".join(missing)
+        corp_label = ", ".join(corp_names) if corp_names else "UNKNOWN"
+        summary_snippet = (event_data.get("summary") or "").strip()
+        context = f"event_type={event_type}, corp_names={corp_label}"
+        if summary_snippet:
+            context = f"{context}, summary={summary_snippet[:120]}"
+        raise ValueError(f"Missing required slots: {missing_str} ({context})")
 
     if date := slots.get("date") or event_data.get("date"):
         if resolved_date := normalize_date(date):
             slots["date"] = resolved_date
 
-    doc_info = _extract_document_info(metadata, event_data)
+    doc_info = extract_document_info(metadata, event_data) or (
+        shared_doc_node.properties if shared_doc_node else None
+    )
     slots["event_id"] = _generate_event_id(
-        corp_name,
+        corp_names,
         event_type,
         slots.get("date"),
         event_data.get("summary", ""),
         doc_info,
+        slots,
     )
 
     return _build_event_graph(
-        corp_name, event_type, slots, event_data.get("summary", ""), doc_info
+        corp_names,
+        event_type,
+        slots,
+        event_data.get("summary", ""),
+        doc_info,
+        shared_doc_node,
     )
 
 
@@ -75,10 +139,12 @@ def build_stock_snapshot_payload(
     indicators: dict[str, Any] | None = None,
 ) -> GraphPayload:
     context = GraphBuildContext()
-    company_node = context.add_node("Company", company)
+    company_node = context.add_node("Company", company, _identity_keys_for("Company"))
 
     price_props = _normalize_stock_price({"traded_at": date, **stock_price})
-    stock_node = context.add_node("StockPrice", price_props)
+    stock_node = context.add_node(
+        "StockPrice", price_props, _identity_keys_for("StockPrice")
+    )
     context.add_edge("HAS_STOCK_PRICE", company_node.key, stock_node.key)
 
     if price_date := _attach_typed_date_node(
@@ -91,7 +157,9 @@ def build_stock_snapshot_payload(
             financials.get("reported_date") or financials.get("date") or date
         )
         fs_props = {**financials, "date": fs_date_value}
-        fs_node = context.add_node("FinancialStatements", fs_props)
+        fs_node = context.add_node(
+            "FinancialStatements", fs_props, _identity_keys_for("FinancialStatements")
+        )
         context.add_edge("HAS_FINANCIAL_STATEMENTS", company_node.key, fs_node.key)
         if fs_date := _attach_typed_date_node(
             context, "FinancialDate", fs_date_value, company_node=company_node
@@ -101,7 +169,9 @@ def build_stock_snapshot_payload(
     if indicators:
         indicator_date = indicators.get("as_of") or indicators.get("date") or date
         indicator_props = {**indicators, "date": indicator_date}
-        indicator_node = context.add_node("Indicator", indicator_props)
+        indicator_node = context.add_node(
+            "Indicator", indicator_props, _identity_keys_for("Indicator")
+        )
         context.add_edge("HAS_INDICATOR", company_node.key, indicator_node.key)
         if ind_date := _attach_typed_date_node(
             context, "IndicatorDate", indicator_date, company_node=company_node
@@ -116,24 +186,38 @@ def build_competitor_payload(
     target_company: dict[str, Any],
 ) -> GraphPayload:
     context = GraphBuildContext()
-    source_node = context.add_node("Company", source_company)
-    target_node = context.add_node("Company", target_company)
+    source_node = context.add_node(
+        "Company", source_company, _identity_keys_for("Company")
+    )
+    target_node = context.add_node(
+        "Company", target_company, _identity_keys_for("Company")
+    )
     context.add_edge("IS_COMPETITOR", source_node.key, target_node.key)
     context.add_edge("IS_COMPETITOR", target_node.key, source_node.key)
     return context.to_payload()
 
 
-def _extract_document_info(
+def extract_document_info(
     metadata: dict[str, Any] | None,
-    event_data: dict[str, Any],
+    event_data: dict[str, Any] | None = None,
 ) -> dict[str, Any] | None:
+    """
+    Extract document information from metadata or event data.
+
+    Args:
+        metadata: Metadata dictionary
+        event_data: Optional event data dictionary
+
+    Returns:
+        Document info dictionary or None
+    """
     candidates = [
         src
         for src in (
             metadata,
             metadata.get("document") if metadata else None,
-            event_data.get("document"),
-            event_data.get("metadata"),
+            event_data.get("document") if event_data else None,
+            event_data.get("metadata") if event_data else None,
         )
         if isinstance(src, dict)
     ]
@@ -152,63 +236,107 @@ def _extract_document_info(
 
     if "document_id" not in cleaned:
         for key in ("rcept_no", "url", "title"):
-            if key in cleaned:
-                cleaned["document_id"] = cleaned[key]
+            value = cleaned.get(key)
+            if _has_value(value) and isinstance(value, str) and value.strip():
+                cleaned["document_id"] = value.strip()
                 break
     return cleaned
 
 
 def _generate_event_id(
-    corp_name: str | None,
+    corp_names: list[str],
     event_type: str | None,
     date: str | None,
     summary: str | None,
     doc_info: dict[str, Any] | None,
+    slots: dict[str, Any] | None,
 ) -> str:
-    if doc_info and doc_info.get("document_id"):
-        content = f"{doc_info['document_id']}::{event_type or ''}"
-    else:
-        parts = [p for p in (corp_name, event_type, date, summary) if p]
-        content = "::".join(parts) if parts else f"EVT_{uuid.uuid4().hex[:12].upper()}"
+    participants = ",".join(sorted(set(corp_names))) if corp_names else None
+    required_slot_fp = ""
+    resolved_date = date
+    if isinstance(slots, dict):
+        definition = ONTOLOGY.event_map.get(event_type or "")
+        required_keys = definition.required_slots if definition else ()
+        required_values = {
+            key: slots.get(key) for key in required_keys if _has_value(slots.get(key))
+        }
+        if required_values:
+            required_slot_fp = _fingerprint(required_values)
+            resolved_date = required_values.get("date") or resolved_date
+
+    parts = [
+        part
+        for part in (
+            event_type or "",
+            participants or "",
+            resolved_date or "",
+            required_slot_fp,
+        )
+        if part
+    ]
+    if not parts:
+        parts = [f"EVT_{uuid.uuid4().hex[:12].upper()}"]
+    content = "::".join(parts)
     digest = hashlib.sha1(content.encode()).hexdigest()
     return f"EVT_{digest[:12].upper()}"
 
 
 def _build_event_graph(
-    corp_name: str,
+    corp_names: list[str],
     event_type: str,
     slots: dict[str, Any],
     summary: str,
     doc_info: dict[str, Any] | None,
+    shared_doc_node: GraphNodeSpec | None = None,
 ) -> GraphPayload:
     context = GraphBuildContext()
 
-    company_node = context.add_node(
-        "Company",
-        {
-            "corp_name": corp_name,
-            "stock_nm": corp_name,
-            "corp_code": slots.get("corp_code"),
-            "stock_code": slots.get("stock_code"),
-        },
-    )
+    date_str = slots.get("date")
+    stock_codes = slots.get("stock_codes")
+    corp_codes = slots.get("corp_codes")
 
     event_props = {
-        **{k: v for k, v in slots.items() if k != "date"},
+        **{
+            k: v
+            for k, v in slots.items()
+            if k not in ("date", "stock_codes", "corp_codes")
+        },
         "type": event_type,
         "summary": summary.strip() if summary else "",
     }
-    event_node = context.add_node("Event", event_props)
-    context.add_edge("INVOLVED_IN", company_node.key, event_node.key)
+    event_node = context.add_node("Event", event_props, _identity_keys_for("Event"))
 
-    if date_str := slots.get("date"):
-        if event_date := _attach_typed_date_node(
-            context, "EventDate", date_str, company_node=company_node
-        ):
-            context.add_edge("OCCURRED_ON", event_node.key, event_date.key)
+    for idx, corp_name in enumerate(corp_names):
+        company_node = context.add_node(
+            "Company",
+            {
+                "corp_name": corp_name,
+                "stock_nm": corp_name,
+                "corp_code": _resolve_company_value(
+                    corp_codes, slots.get("corp_code"), corp_name, idx, corp_names
+                ),
+                "stock_code": _resolve_company_value(
+                    stock_codes, slots.get("stock_code"), corp_name, idx, corp_names
+                ),
+            },
+            _identity_keys_for("Company"),
+        )
+        context.add_edge("INVOLVED_IN", company_node.key, event_node.key)
 
-    if doc_info:
-        doc_node = context.add_node("Document", doc_info)
+        if date_str:
+            event_date = _attach_typed_date_node(
+                context, "EventDate", date_str, company_node=company_node
+            )
+            if event_date:
+                context.add_edge("OCCURRED_ON", event_node.key, event_date.key)
+
+    doc_node = shared_doc_node
+    if not doc_node and doc_info:
+        doc_node = context.add_node(
+            "Document", doc_info, _identity_keys_for("Document")
+        )
+    if doc_node:
+        context.nodes[doc_node.key] = doc_node
         context.add_edge("REPORTED_BY", event_node.key, doc_node.key)
 
     return context.to_payload()
@@ -218,6 +346,46 @@ def _normalize_stock_price(props: dict[str, Any]) -> dict[str, Any]:
     props.setdefault("stck_prpr", props.get("stck_clpr"))
     props.setdefault("stck_clpr", props.get("stck_prpr"))
     return props
+
+
+def _normalize_corp_names(
+    event_data: dict[str, Any],
+    slots: dict[str, Any],
+) -> list[str]:
+    names: list[str] = []
+    for source in (
+        event_data.get("corp_names"),
+        slots.get("corp_names"),
+        event_data.get("corp_name"),
+        slots.get("corp_name"),
+    ):
+        if isinstance(source, list):
+            names.extend(source)
+        elif isinstance(source, str):
+            names.append(source)
+    return [
+        name
+        for name in dict.fromkeys(
+            name.strip() for name in names if isinstance(name, str)
+        )
+        if name
+    ]
+
+
+def _autofill_counterparty(
+    definition: EventDefinition, slots: dict[str, Any], corp_names: list[str]
+) -> None:
+    if "counterparty" not in definition.required_slots:
+        return
+    if _has_value(slots.get("counterparty")):
+        return
+    if len(corp_names) < 2:
+        return
+
+    counterparts = [name for name in corp_names[1:] if name]
+    if not counterparts:
+        return
+    slots["counterparty"] = counterparts if len(counterparts) > 1 else counterparts[0]
 
 
 def _attach_typed_date_node(
@@ -230,10 +398,42 @@ def _attach_typed_date_node(
     if not date_props:
         return None
 
-    hub_date = context.add_node("Date", date_props)
+    hub_date = context.add_node("Date", date_props, _identity_keys_for("Date"))
     if company_node:
         context.add_edge("ON_DATE", company_node.key, hub_date.key)
 
-    typed_date = context.add_node(label, date_props)
+    typed_date = context.add_node(label, date_props, _identity_keys_for(label))
     context.add_edge("IS_DATE", typed_date.key, hub_date.key)
     return typed_date
+
+
+def _resolve_company_value(
+    mapping: Any,
+    shared_value: Any,
+    corp_name: str,
+    position: int | None = None,
+    corp_names: list[str] | None = None,
+) -> Any:
+    if isinstance(mapping, dict) and corp_name in mapping:
+        return mapping.get(corp_name)
+    if isinstance(mapping, (list, tuple)) and position is not None:
+        return mapping[position] if position < len(mapping) else None
+    if isinstance(mapping, (list, tuple)) and corp_names:
+        try:
+            idx = corp_names.index(corp_name)
+        except ValueError:
+            idx = None
+        return mapping[idx] if idx is not None and idx < len(mapping) else None
+    return shared_value
+
+
+def _identity_keys_for(label: str) -> tuple[str, ...]:
+    return _NODE_IDENTITIES.get(label, ())
+
+
+def _fingerprint(value: Any) -> str:
+    try:
+        payload = json.dumps(value, ensure_ascii=False, sort_keys=True)
+    except TypeError:
+        payload = str(value)
+    return hashlib.sha1(payload.encode()).hexdigest()[:12]

--- a/src/stockelper_kg/graph/payload.py
+++ b/src/stockelper_kg/graph/payload.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import hashlib
 import json
-import uuid
 from typing import Any
 
 from ..utils.dates import build_date_properties, normalize_date
@@ -45,7 +44,7 @@ def build_multi_event_payload(
             )
         except Exception as exc:
             event_type = event_data.get("event_type", "UNKNOWN")
-            corp = event_data.get("corp_names") or event_data.get("corp_name")
+            corp = event_data.get("corp_names")
             label = corp if isinstance(corp, str) else ", ".join(corp or [])
             raise ValueError(
                 f"Failed to build payload for event #{idx} ({event_type} | {label}): {exc}"
@@ -80,26 +79,24 @@ def build_graph_payload(
         if isinstance(data, dict):
             slots.update(data)
 
+    summary_text = event_data.get("summary", "")
     sentiment_score = event_data.get("sentiment_score")
     if sentiment_score is not None:
         slots["sentiment_score"] = sentiment_score
 
-    corp_names = _normalize_corp_names(event_data, slots)
-    if not corp_names:
-        raise ValueError("corp_name is required")
-    slots["corp_names"] = corp_names
-    slots["corp_name"] = corp_names[0]
+    corp_names_raw = event_data.get("corp_names")
+    if not isinstance(corp_names_raw, list):
+        raise ValueError("corp_names must be a list")
+    corp_names = _normalize_corp_names(corp_names_raw)
     event_data["corp_names"] = corp_names
-    event_data["corp_name"] = corp_names[0]
 
-    # TODO: Behavior Change - auto-fill counterparty from corp_names when missing
     _autofill_counterparty(definition, slots, corp_names)
 
     missing = [s for s in definition.required_slots if not _has_value(slots.get(s))]
     if missing:
         missing_str = ", ".join(missing)
-        corp_label = ", ".join(corp_names) if corp_names else "UNKNOWN"
-        summary_snippet = (event_data.get("summary") or "").strip()
+        corp_label = ", ".join(corp_names)
+        summary_snippet = (summary_text or "").strip()
         context = f"event_type={event_type}, corp_names={corp_label}"
         if summary_snippet:
             context = f"{context}, summary={summary_snippet[:120]}"
@@ -116,7 +113,7 @@ def build_graph_payload(
         corp_names,
         event_type,
         slots.get("date"),
-        event_data.get("summary", ""),
+        summary_text,
         doc_info,
         slots,
     )
@@ -125,7 +122,7 @@ def build_graph_payload(
         corp_names,
         event_type,
         slots,
-        event_data.get("summary", ""),
+        summary_text,
         doc_info,
         shared_doc_node,
     )
@@ -237,7 +234,7 @@ def extract_document_info(
     if "document_id" not in cleaned:
         for key in ("rcept_no", "url", "title"):
             value = cleaned.get(key)
-            if _has_value(value) and isinstance(value, str) and value.strip():
+            if _has_value(value) and isinstance(value, str):
                 cleaned["document_id"] = value.strip()
                 break
     return cleaned
@@ -249,20 +246,19 @@ def _generate_event_id(
     date: str | None,
     summary: str | None,
     doc_info: dict[str, Any] | None,
-    slots: dict[str, Any] | None,
+    slots: dict[str, Any],
 ) -> str:
-    participants = ",".join(sorted(set(corp_names))) if corp_names else None
+    participants = ",".join(sorted(set(corp_names)))
     required_slot_fp = ""
     resolved_date = date
-    if isinstance(slots, dict):
-        definition = ONTOLOGY.event_map.get(event_type or "")
-        required_keys = definition.required_slots if definition else ()
-        required_values = {
-            key: slots.get(key) for key in required_keys if _has_value(slots.get(key))
-        }
-        if required_values:
-            required_slot_fp = _fingerprint(required_values)
-            resolved_date = required_values.get("date") or resolved_date
+    definition = ONTOLOGY.event_map.get(event_type or "")
+    required_keys = definition.required_slots if definition else ()
+    required_values = {
+        key: slots.get(key) for key in required_keys if _has_value(slots.get(key))
+    }
+    if required_values:
+        required_slot_fp = _fingerprint(required_values)
+        resolved_date = required_values.get("date") or resolved_date
 
     parts = [
         part
@@ -274,8 +270,6 @@ def _generate_event_id(
         )
         if part
     ]
-    if not parts:
-        parts = [f"EVT_{uuid.uuid4().hex[:12].upper()}"]
     content = "::".join(parts)
     digest = hashlib.sha1(content.encode()).hexdigest()
     return f"EVT_{digest[:12].upper()}"
@@ -306,18 +300,24 @@ def _build_event_graph(
     }
     event_node = context.add_node("Event", event_props, _identity_keys_for("Event"))
 
-    for idx, corp_name in enumerate(corp_names):
+    for corp_name in corp_names:
+        corp_code = (
+            corp_codes.get(corp_name)
+            if isinstance(corp_codes, dict)
+            else slots.get("corp_code")
+        )
+        stock_code = (
+            stock_codes.get(corp_name)
+            if isinstance(stock_codes, dict)
+            else slots.get("stock_code")
+        )
         company_node = context.add_node(
             "Company",
             {
                 "corp_name": corp_name,
                 "stock_nm": corp_name,
-                "corp_code": _resolve_company_value(
-                    corp_codes, slots.get("corp_code"), corp_name, idx, corp_names
-                ),
-                "stock_code": _resolve_company_value(
-                    stock_codes, slots.get("stock_code"), corp_name, idx, corp_names
-                ),
+                "corp_code": corp_code,
+                "stock_code": stock_code,
             },
             _identity_keys_for("Company"),
         )
@@ -348,43 +348,24 @@ def _normalize_stock_price(props: dict[str, Any]) -> dict[str, Any]:
     return props
 
 
-def _normalize_corp_names(
-    event_data: dict[str, Any],
-    slots: dict[str, Any],
-) -> list[str]:
-    names: list[str] = []
-    for source in (
-        event_data.get("corp_names"),
-        slots.get("corp_names"),
-        event_data.get("corp_name"),
-        slots.get("corp_name"),
-    ):
-        if isinstance(source, list):
-            names.extend(source)
-        elif isinstance(source, str):
-            names.append(source)
-    return [
-        name
-        for name in dict.fromkeys(
-            name.strip() for name in names if isinstance(name, str)
-        )
-        if name
-    ]
+def _normalize_corp_names(names: list[str]) -> list[str]:
+    corp_names = list(dict.fromkeys(n.strip() for n in names if n.strip()))
+    if not corp_names:
+        raise ValueError("corp_names is required")
+    return corp_names
 
 
 def _autofill_counterparty(
     definition: EventDefinition, slots: dict[str, Any], corp_names: list[str]
 ) -> None:
-    if "counterparty" not in definition.required_slots:
-        return
-    if _has_value(slots.get("counterparty")):
-        return
-    if len(corp_names) < 2:
+    if (
+        "counterparty" not in definition.required_slots
+        or _has_value(slots.get("counterparty"))
+        or len(corp_names) < 2
+    ):
         return
 
-    counterparts = [name for name in corp_names[1:] if name]
-    if not counterparts:
-        return
+    counterparts = corp_names[1:]
     slots["counterparty"] = counterparts if len(counterparts) > 1 else counterparts[0]
 
 
@@ -405,26 +386,6 @@ def _attach_typed_date_node(
     typed_date = context.add_node(label, date_props, _identity_keys_for(label))
     context.add_edge("IS_DATE", typed_date.key, hub_date.key)
     return typed_date
-
-
-def _resolve_company_value(
-    mapping: Any,
-    shared_value: Any,
-    corp_name: str,
-    position: int | None = None,
-    corp_names: list[str] | None = None,
-) -> Any:
-    if isinstance(mapping, dict) and corp_name in mapping:
-        return mapping.get(corp_name)
-    if isinstance(mapping, (list, tuple)) and position is not None:
-        return mapping[position] if position < len(mapping) else None
-    if isinstance(mapping, (list, tuple)) and corp_names:
-        try:
-            idx = corp_names.index(corp_name)
-        except ValueError:
-            idx = None
-        return mapping[idx] if idx is not None and idx < len(mapping) else None
-    return shared_value
 
 
 def _identity_keys_for(label: str) -> tuple[str, ...]:

--- a/src/stockelper_kg/graph/schema.py
+++ b/src/stockelper_kg/graph/schema.py
@@ -46,16 +46,27 @@ class GraphBuildContext:
     nodes: Dict[str, GraphNodeSpec] = field(default_factory=dict)
     edges: list[GraphEdgeSpec] = field(default_factory=list)
 
-    def add_node(self, label: str, properties: Dict[str, Any]) -> GraphNodeSpec:
+    def add_node(
+        self,
+        label: str,
+        properties: Dict[str, Any],
+        identity_keys: Tuple[str, ...] = (),
+    ) -> GraphNodeSpec:
         props = clean_props(properties)
         if not props:
             raise ValueError(f"{label} node requires at least one property")
-        key = _make_key(label, props)
-        node = GraphNodeSpec(label, key, props)
-        if existing := self.nodes.get(key):
-            merged = {**existing.properties, **props}
-            node = GraphNodeSpec(node.label, key, merged)
-        self.nodes[node.key] = node
+
+        key_props = _pick_identity_props(props, identity_keys)
+        key = _make_key(label, key_props)
+        existing = self.nodes.get(key)
+        merged_props = {**existing.properties, **props} if existing else props
+        identity = (
+            existing.identity_keys
+            if existing and existing.identity_keys
+            else identity_keys if key_props and identity_keys else ()
+        )
+        node = GraphNodeSpec(label, key, merged_props, identity)
+        self.nodes[key] = node
         return node
 
     def add_edge(self, edge_type: str, source: str, target: str) -> None:
@@ -80,9 +91,33 @@ def _make_key(label: str, props: Dict[str, Any]) -> str:
     return f"{label}::{digest[:12]}"
 
 
+def _pick_identity_props(
+    props: Dict[str, Any], identity_keys: Tuple[str, ...]
+) -> Dict[str, Any]:
+    if not identity_keys:
+        return props
+
+    key_props = {
+        k: props[k]
+        for k in identity_keys
+        if k in props and _has_value(props[k])
+    }
+    return key_props or props
+
+
+def _has_value(val: Any) -> bool:
+    if isinstance(val, str):
+        return bool(val.strip())
+    if isinstance(val, (list, tuple, set, dict)):
+        return bool(val)
+    return val is not None
+
+
 def clean_props(props: Dict[str, Any]) -> Dict[str, Any]:
     return {
         k: (v.strip() if isinstance(v, str) else v)
         for k, v in props.items()
-        if v is not None and (not isinstance(v, str) or v.strip())
+        if v is not None
+        and (not isinstance(v, str) or v.strip())
+        and not isinstance(v, dict)
     }

--- a/src/stockelper_kg/pipeline.py
+++ b/src/stockelper_kg/pipeline.py
@@ -17,7 +17,6 @@ from .graph.ontology import ONTOLOGY
 from .graph.payload import (
     build_graph_payload,
     _autofill_counterparty,
-    _generate_event_id,
     _identity_keys_for,
     _normalize_corp_names,
 )
@@ -84,7 +83,6 @@ class EventPipeline:
     ) -> list[EventResult]:
         logger.info("Analyzing event...")
         events = classify_events(text)
-        events = self._dedupe_events(events)
         results: list[EventResult] = []
 
         for event_data in events:
@@ -103,20 +101,20 @@ class EventPipeline:
         if not isinstance(event_data.get("optional_slots"), dict):
             event_data["optional_slots"] = {}
 
-        corp_names = _normalize_corp_names(event_data, slots)
+        corp_names = _normalize_corp_names(
+            event_data.get("corp_names")
+            if isinstance(event_data.get("corp_names"), list)
+            else []
+        )
         if not corp_names and metadata:
-            meta = metadata.get("corp_names") or metadata.get("corp_name")
+            meta = metadata.get("corp_names")
             if isinstance(meta, list):
                 corp_names = [str(n).strip() for n in meta if str(n).strip()]
-            elif isinstance(meta, str) and meta.strip():
-                corp_names = [meta.strip()]
 
         if not corp_names:
-            raise ValueError("corp_name is required")
+            raise ValueError("corp_names is required")
 
-        corp_name = corp_names[0]
         event_data["corp_names"] = slots["corp_names"] = corp_names
-        event_data["corp_name"] = slots["corp_name"] = corp_name
 
         date = slots.get("date") or event_data.get("date")
         if date and (normalized := normalize_date(date)):
@@ -152,12 +150,11 @@ class EventPipeline:
         ]
         if missing:
             missing_str = ", ".join(missing)
-            corp_label = ", ".join(corp_names) if corp_names else "UNKNOWN"
-            summary_snippet = (event_data.get("summary") or "").strip()
             context = (
-                f"event_type={event_data.get('event_type')}, corp_names={corp_label}"
+                f"event_type={event_data.get('event_type')}, "
+                f"corp_names={', '.join(corp_names) if corp_names else 'UNKNOWN'}"
             )
-            if summary_snippet:
+            if summary_snippet := (event_data.get("summary") or "").strip():
                 context = f"{context}, summary={summary_snippet[:120]}"
             raise ValueError(f"Missing required slots: {missing_str} ({context})")
 
@@ -168,46 +165,6 @@ class EventPipeline:
             date=slots.get("date"),
         )
 
-    def _dedupe_events(self, events: list[dict[str, Any]]) -> list[dict[str, Any]]:
-        # TODO: Behavior Change - drop duplicate events using generated event_id
-        seen: set[str] = set()
-        deduped: list[dict[str, Any]] = []
-        for event in events:
-            slots = (
-                event.get("required_slots")
-                if isinstance(event.get("required_slots"), dict)
-                else {}
-            )
-            corp_names = event.get("corp_names") or [event.get("corp_name")]
-            if isinstance(corp_names, list):
-                corp_names = [corp for corp in corp_names if corp]
-            else:
-                corp_names = [corp_names] if corp_names else []
-            event_type = event.get("event_type")
-            date = slots.get("date") or event.get("date")
-            if not (corp_names and event_type and date):
-                deduped.append(event)
-                continue
-            event_id = _generate_event_id(
-                corp_names,
-                event_type,
-                date,
-                event.get("summary", ""),
-                None,
-                slots,
-            )
-            if event_id in seen:
-                logger.info(
-                    "Dropping duplicate event: %s | %s | %s",
-                    event_type,
-                    corp_names[0],
-                    date,
-                )
-                continue
-            seen.add(event_id)
-            deduped.append(event)
-        return deduped
-
     def _save_events_batch(
         self,
         results: list[EventResult],
@@ -217,15 +174,16 @@ class EventPipeline:
         from .graph.payload import build_multi_event_payload
 
         events_data = [r.event_data for r in results]
-        first_names = [
-            r.event_data.get("corp_names", [r.event_data.get("corp_name", "")])[0]
-            for r in results[:3]
-        ]
+        first_names: list[str] = []
+        for result in results[:3]:
+            corp_names = result.event_data.get("corp_names")
+            if isinstance(corp_names, list) and corp_names:
+                first_names.append(corp_names[0])
         corp_label = ", ".join(first_names)
         if len(results) > 3:
             corp_label += f" ... (+{len(results) - 3} more)"
 
-        logger.info("[%s] Saving %d event(s) in batch...", corp_label, len(results))
+        logger.info(f"[{corp_label}] Saving {len(results)} event(s) in batch...")
         payload = build_multi_event_payload(events_data, metadata=metadata)
         self.client.execute_query(payload_to_cypher(payload))
 
@@ -235,9 +193,13 @@ class EventPipeline:
         metadata: dict[str, Any] | None,
         shared_doc_node=None,
     ) -> None:
-        corp_names = event_data.get("corp_names") or [event_data.get("corp_name")]
-        corp_label = ", ".join(c for c in corp_names if c) or "UNKNOWN"
-        logger.info("[%s] Saving event graph...", corp_label)
+        corp_names = event_data.get("corp_names")
+        corp_label = (
+            ", ".join(c for c in corp_names if c)
+            if isinstance(corp_names, list)
+            else "UNKNOWN"
+        )
+        logger.info(f"[{corp_label}] Saving event graph...")
         payload = build_graph_payload(
             event_data, metadata=metadata, shared_doc_node=shared_doc_node
         )
@@ -274,17 +236,17 @@ class EventPipeline:
         self, stock_code: str, date: str, corp_name: str | None = None
     ) -> None:
         label = corp_name or stock_code
-        logger.info("[%s] Collecting company data...", label)
+        logger.info(f"[{label}] Collecting company data...")
         try:
             df = self.collector.collect(stock_code, date)
             if df.empty:
-                logger.warning("[%s] No data collected", label)
+                logger.warning(f"[{label}] No data collected")
                 return
 
             self.graph_builder.build_graph(df, stock_code, [date])
-            logger.info("[%s] Graph updated", label)
+            logger.info(f"[{label}] Graph updated")
         except Exception as e:
-            logger.error("[%s] Failed to update company graph: %s", label, e)
+            logger.error(f"[{label}] Failed to update company graph: {e}")
 
 
 def create_pipeline(config: Config) -> EventPipeline:

--- a/src/stockelper_kg/pipeline.py
+++ b/src/stockelper_kg/pipeline.py
@@ -12,8 +12,16 @@ from .collectors.mongodb import MongoDBCollector
 from .config import Config
 from .graph import GraphBuilder, Neo4jClient
 from .graph.cypher import payload_to_cypher
-from .graph.event import classify_event
-from .graph.payload import build_graph_payload
+from .graph.event import classify_events
+from .graph.ontology import ONTOLOGY
+from .graph.payload import (
+    build_graph_payload,
+    _autofill_counterparty,
+    _generate_event_id,
+    _identity_keys_for,
+    _normalize_corp_names,
+)
+from .graph.schema import _has_value
 from .utils.dates import normalize_date
 
 logger = logging.getLogger(__name__)
@@ -22,7 +30,8 @@ logger = logging.getLogger(__name__)
 @dataclass
 class EventResult:
     event_data: dict[str, Any]
-    stock_code: str | None = None
+    corp_names: list[str]
+    stock_codes: dict[str, str]
     date: str | None = None
 
 
@@ -41,12 +50,24 @@ class EventPipeline:
         self,
         event_text: str,
         metadata: dict[str, Any] | None = None,
-    ) -> dict[str, Any]:
-        result = self._analyze(event_text, metadata)
-        self._save_event(result.event_data, metadata)
-        if result.stock_code and result.date:
-            self._save_company(result.stock_code, result.date)
-        return result.event_data
+        batch_mode: bool = True,
+    ) -> list[dict[str, Any]]:
+        results = self._analyze(event_text, metadata)
+        if not results:
+            logger.warning("No events extracted from text")
+            return []
+
+        shared_doc_node = self._create_shared_doc_node(metadata, results)
+
+        if batch_mode and len(results) > 1:
+            self._save_events_batch(results, metadata, shared_doc_node)
+        else:
+            for result in results:
+                self._save_event(result.event_data, metadata, shared_doc_node)
+
+        self._save_companies(results)
+
+        return [result.event_data for result in results]
 
     def _create_collector(self, config: Config) -> EventCollector:
         return EventCollector(
@@ -60,58 +81,210 @@ class EventPipeline:
 
     def _analyze(
         self, text: str, metadata: dict[str, Any] | None = None
-    ) -> EventResult:
+    ) -> list[EventResult]:
         logger.info("Analyzing event...")
-        event_data = classify_event(text)
+        events = classify_events(text)
+        events = self._dedupe_events(events)
+        results: list[EventResult] = []
 
-        slots = event_data.get("required_slots", {})
+        for event_data in events:
+            result = self._process_single_event(event_data, metadata)
+            results.append(result)
+
+        return results
+
+    def _process_single_event(
+        self, event_data: dict[str, Any], metadata: dict[str, Any] | None = None
+    ) -> EventResult:
+        slots = event_data.get("required_slots")
         if not isinstance(slots, dict):
             slots = {}
             event_data["required_slots"] = slots
+        if not isinstance(event_data.get("optional_slots"), dict):
+            event_data["optional_slots"] = {}
 
-        corp_name = (event_data.get("corp_name") or "").strip()
-        if not corp_name and metadata:
-            corp_name = (metadata.get("corp_name") or "").strip()
-        if not corp_name:
+        corp_names = _normalize_corp_names(event_data, slots)
+        if not corp_names and metadata:
+            meta = metadata.get("corp_names") or metadata.get("corp_name")
+            if isinstance(meta, list):
+                corp_names = [str(n).strip() for n in meta if str(n).strip()]
+            elif isinstance(meta, str) and meta.strip():
+                corp_names = [meta.strip()]
+
+        if not corp_names:
             raise ValueError("corp_name is required")
-        slots["corp_name"] = corp_name
-        event_data["corp_name"] = corp_name
 
-        if raw_date := slots.get("date") or event_data.get("date"):
-            if normalized_date := normalize_date(raw_date):
-                slots["date"] = event_data["date"] = normalized_date
+        corp_name = corp_names[0]
+        event_data["corp_names"] = slots["corp_names"] = corp_names
+        event_data["corp_name"] = slots["corp_name"] = corp_name
 
-        stock_code = slots.get("stock_code") or self.collector.resolve(corp_name)
-        if stock_code:
-            slots["stock_code"] = stock_code
+        date = slots.get("date") or event_data.get("date")
+        if date and (normalized := normalize_date(date)):
+            slots["date"] = event_data["date"] = normalized
+
+        raw_codes = slots.get("stock_codes")
+        raw_codes = raw_codes if isinstance(raw_codes, dict) else {}
+        stock_codes: dict[str, str] = {}
+        for corp_name in corp_names:
+            code = (
+                raw_codes.get(corp_name)
+                or slots.get("stock_code")
+                or self.collector.resolve(corp_name)
+            )
+            if code:
+                stock_codes[corp_name] = code
+
+        if stock_codes:
+            slots.setdefault("stock_codes", {}).update(stock_codes)
+            if len(stock_codes) == 1:
+                slots["stock_code"] = next(iter(stock_codes.values()))
+
+        definition = ONTOLOGY.event_map.get(event_data.get("event_type"))
+        if not definition:
+            raise ValueError(f"Unknown event_type: {event_data.get('event_type')}")
+
+        _autofill_counterparty(definition, slots, corp_names)
+
+        missing = [
+            slot
+            for slot in definition.required_slots
+            if not _has_value(slots.get(slot))
+        ]
+        if missing:
+            missing_str = ", ".join(missing)
+            corp_label = ", ".join(corp_names) if corp_names else "UNKNOWN"
+            summary_snippet = (event_data.get("summary") or "").strip()
+            context = (
+                f"event_type={event_data.get('event_type')}, corp_names={corp_label}"
+            )
+            if summary_snippet:
+                context = f"{context}, summary={summary_snippet[:120]}"
+            raise ValueError(f"Missing required slots: {missing_str} ({context})")
 
         return EventResult(
-            event_data=event_data, stock_code=stock_code, date=slots.get("date")
+            event_data=event_data,
+            corp_names=corp_names,
+            stock_codes=stock_codes,
+            date=slots.get("date"),
         )
+
+    def _dedupe_events(self, events: list[dict[str, Any]]) -> list[dict[str, Any]]:
+        # TODO: Behavior Change - drop duplicate events using generated event_id
+        seen: set[str] = set()
+        deduped: list[dict[str, Any]] = []
+        for event in events:
+            slots = (
+                event.get("required_slots")
+                if isinstance(event.get("required_slots"), dict)
+                else {}
+            )
+            corp_names = event.get("corp_names") or [event.get("corp_name")]
+            if isinstance(corp_names, list):
+                corp_names = [corp for corp in corp_names if corp]
+            else:
+                corp_names = [corp_names] if corp_names else []
+            event_type = event.get("event_type")
+            date = slots.get("date") or event.get("date")
+            if not (corp_names and event_type and date):
+                deduped.append(event)
+                continue
+            event_id = _generate_event_id(
+                corp_names,
+                event_type,
+                date,
+                event.get("summary", ""),
+                None,
+                slots,
+            )
+            if event_id in seen:
+                logger.info(
+                    "Dropping duplicate event: %s | %s | %s",
+                    event_type,
+                    corp_names[0],
+                    date,
+                )
+                continue
+            seen.add(event_id)
+            deduped.append(event)
+        return deduped
+
+    def _save_events_batch(
+        self,
+        results: list[EventResult],
+        metadata: dict[str, Any] | None,
+        shared_doc_node=None,
+    ) -> None:
+        from .graph.payload import build_multi_event_payload
+
+        events_data = [r.event_data for r in results]
+        first_names = [
+            r.event_data.get("corp_names", [r.event_data.get("corp_name", "")])[0]
+            for r in results[:3]
+        ]
+        corp_label = ", ".join(first_names)
+        if len(results) > 3:
+            corp_label += f" ... (+{len(results) - 3} more)"
+
+        logger.info("[%s] Saving %d event(s) in batch...", corp_label, len(results))
+        payload = build_multi_event_payload(events_data, metadata=metadata)
+        self.client.execute_query(payload_to_cypher(payload))
 
     def _save_event(
         self,
         event_data: dict[str, Any],
         metadata: dict[str, Any] | None,
+        shared_doc_node=None,
     ) -> None:
-        corp_name = event_data.get("corp_name")
-        logger.info("[%s] Saving event graph...", corp_name)
-        payload = build_graph_payload(event_data, metadata=metadata)
-        cypher = payload_to_cypher(payload)
-        self.client.execute_query(cypher)
+        corp_names = event_data.get("corp_names") or [event_data.get("corp_name")]
+        corp_label = ", ".join(c for c in corp_names if c) or "UNKNOWN"
+        logger.info("[%s] Saving event graph...", corp_label)
+        payload = build_graph_payload(
+            event_data, metadata=metadata, shared_doc_node=shared_doc_node
+        )
+        self.client.execute_query(payload_to_cypher(payload))
 
-    def _save_company(self, stock_code: str, date: str) -> None:
-        logger.info("[%s] Collecting company data...", stock_code)
+    def _create_shared_doc_node(
+        self,
+        metadata: dict[str, Any] | None,
+        results: list[EventResult],
+    ):
+        from .graph.payload import extract_document_info
+        from .graph.schema import GraphBuildContext
+
+        doc_info = extract_document_info(metadata)
+        if not doc_info and results and results[0].event_data:
+            doc_info = extract_document_info(metadata, results[0].event_data)
+        if not doc_info:
+            return None
+        context = GraphBuildContext()
+        return context.add_node("Document", doc_info, _identity_keys_for("Document"))
+
+    def _save_companies(self, results: list[EventResult]) -> None:
+        unique_companies = {}
+        for result in results:
+            if not result.date:
+                continue
+            for corp_name, stock_code in result.stock_codes.items():
+                unique_companies.setdefault(stock_code, (result.date, corp_name))
+
+        for stock_code, (date, corp_name) in unique_companies.items():
+            self._save_company(stock_code, date, corp_name)
+
+    def _save_company(
+        self, stock_code: str, date: str, corp_name: str | None = None
+    ) -> None:
+        label = corp_name or stock_code
+        logger.info("[%s] Collecting company data...", label)
         try:
             df = self.collector.collect(stock_code, date)
             if df.empty:
-                logger.warning("[%s] No data collected", stock_code)
+                logger.warning("[%s] No data collected", label)
                 return
 
             self.graph_builder.build_graph(df, stock_code, [date])
-            logger.info("[%s] Graph updated", stock_code)
+            logger.info("[%s] Graph updated", label)
         except Exception as e:
-            logger.error("[%s] Failed to update company graph: %s", stock_code, e)
+            logger.error("[%s] Failed to update company graph: %s", label, e)
 
 
 def create_pipeline(config: Config) -> EventPipeline:


### PR DESCRIPTION
### 멀티 이벤트를 추출하도록 확장
- 단일 이벤트만 추출되었는데, 다른 내용의 이벤트라면 멀티 이벤트를 저장하도록 기능 추가.
- 혹은 한 기사에서 여러 기업을 언급하는 경우도 있는데, 리스트 형태로 받아 여러 기업을 받을 수 있도록 함.
<img width="825" height="944" alt="image" src="https://github.com/user-attachments/assets/ef72d7ce-79a7-4219-861f-f70cdec7456c" />


#### TODO
- 다른 Document가 같은 이벤트를 바라보지 않도록 기능 개발 필요 -> 현재는 필요 없을 것으로 논의 완료